### PR TITLE
Config: 프로젝트 초기 세팅(Security, DB, Swagger 설정)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcer'
+    
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  postgresql-database:
+    container_name: tdd-db
+    image: postgres:18
+    restart: always
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: tdd-db
+      TZ: Asia/Seoul
+    ports:
+      - "5433:5432"

--- a/src/main/java/com/sparta/tdd/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/tdd/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.sparta.tdd.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final String[] readOnlyUrl = {
+        "/favicon.ico",
+        "/api-docs/**",
+        "/v3/api-docs/**",
+        "/swagger-ui/**", "/swagger",
+        "/v1/auth/**"
+    };
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, readOnlyUrl).permitAll()
+                    .anyRequest().authenticated())
+        ;
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/sparta/tdd/global/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/tdd/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.sparta.tdd.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    
+    @Bean
+    public OpenAPI toTastyApi() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("TDD API")
+                .description("TDD API 명세서")
+                .version("v1"))
+            .servers(List.of(new Server().url("http://localhost:8080").description("로컬 서버")))
+            .components(new Components()
+                .addSecuritySchemes("AccessToken",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+            .addSecurityItem(new SecurityRequirement().addList("AccessToken"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,61 @@
-spring.application.name=TDD
+spring:
+  application:
+    name: TDD
+  profiles:
+    active: local
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+        format_sql: true
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5433/tdd-db
+    username: test
+    password: password
+    driver-class-name: org.postgresql.Driver
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: OFF
+    org.hibernate.type.descriptor.sql.BasicBinder: OFF


### PR DESCRIPTION
## PR 설명  
  
- [config: swagger 의존성 추가](https://github.com/Sparta-21/TDD/commit/8635f8cf6c919fdde7cd89adb8f9a65f1e86bce7)

- [config: 공통 환경에서 DB 사용을 위한 docker-compose.yml 추가](https://github.com/Sparta-21/TDD/commit/1630cd94ee0d25efb784f9182df141db23f45dc2)
  - 환경마다 동일한 DB 사용을 위해 docker-compose.yml 파일을 추가했습니다.

- [config: SecurityConfig 기본 설정 진행](https://github.com/Sparta-21/TDD/commit/6a7ebe0716de0a55b79cf0cff96afa1bd5c1fb5f)
  - 백엔드 프로젝트만 진행하기 때문에 CORS 설정이 불필요하다고 판단해 제거했습니다.
  - DB 내 패스워드 암호화를 위한 `BCryptPasswordEncoder`를 설정했습니다.

- [config: Swagger 기본 설정 진행 및 application.yml 설정 추가](https://github.com/Sparta-21/TDD/commit/57ab4e7755a1f8d43b6e8243d429878ee3fd23b4)
  - 기본적인 jpa, swagger 및 db 설정을 추가했습니다.
  - 로컬 환경과 배포 환경에서 설정값이 다를 수 있는 부분을 프로필로 구분했습니다.

## 리뷰 포인트  
추가로 이번 PR에서 설정하고 싶으신 부분 있으면 댓글로 남겨주시면 작업하도록 하겠습니다.
환경 변수의 경우는 별도의 문서로 노션에 작성해두겠습니다.