### PR TITLE
feat(user): User 엔티티 닉네임 추가 및 update 메서드 구현

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/tdd/domain/user/entity/User.java
@@ -35,7 +35,22 @@ public class User extends BaseEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "authority", nullable = false, length = 20)
     private UserAuthority authority;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    public void updateAuthority(UserAuthority authority) {
+        this.authority = authority;
+    }
 }

--- a/src/test/java/com/sparta/tdd/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.sparta.tdd.domain.user.repository;
+
+import com.sparta.tdd.domain.user.entity.User;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("local")
+class UserRepositoryTest {
+
+    private User user;
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        user = User.builder()
+                .username("test01")
+                .password("test12345")
+                .nickname("")
+                .authority(UserAuthority.CUSTOMER)
+                .build();
+    }
+    @Test
+    void signup() {
+        //when
+        userRepository.save(user);
+
+        //then
+        assertEquals(true, userRepository.existsByUsername("test01"));
+    }
+    @Test
+    void readUserProfile() {
+        //given
+        userRepository.save(user);
+
+        //when
+        User findUser = userRepository.findByUsername("test01").get();
+
+        //then
+        assertEquals(user.getId(), findUser.getId());
+        assertEquals(user.getUsername(), findUser.getUsername());
+        assertEquals(UserAuthority.CUSTOMER, findUser.getAuthority());
+    }
+    @Test
+    void updateUserProfile() {
+        //given
+        userRepository.save(user);
+
+        //when
+        User findUser = userRepository.findByUsername("test01").get();
+        findUser.updateNickname("test2");
+        findUser.updateAuthority(UserAuthority.MANAGER);
+
+        User updatedUser = userRepository.findByUsername("test01").get();
+
+        //then
+        assertEquals(findUser.getNickname(), updatedUser.getNickname());
+        assertEquals(findUser.getAuthority(), updatedUser.getAuthority());
+    }
+    @Test
+    void deleteUser() {
+        //given
+        userRepository.save(user);
+
+        //when
+        userRepository.delete(user);
+
+        //then
+        assertEquals(false, userRepository.existsByUsername("test01"));
+    }
+}


### PR DESCRIPTION
- User 엔티티에 닉네임 컬럼 추가
- User 엔티티의 수정용 udpate 메서드 추가
- UserRepository를 이용한 User 엔티티 CRUD 테스트 진행