### PR TITLE
chore: 코드오너 지정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dnjsals45 @bbangjae @p990805 @Doritosch @yeon-22k @yawning5


### PR DESCRIPTION
## PR 내용

- 매번 PR 작성시 리뷰어를 등록해야하는 불편함이 있어, Auto Assign이 가능한 코드오너 파일을 생성했습니다.
- main 브랜치에 merge되어야 동작하기 떄문에 base를 main으로 설정했습니다.