### PR TITLE
chore: CODEOWNERS 내용 main -> dev 동기화

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dnjsals45 @bbangjae @p990805 @Doritosch @yeon-22k @yawning5


### PR DESCRIPTION
## PR 내용

- Git flow를 이용하다보니 Default 브랜치가 dev로 설정되어 main이 아닌 dev로 지정해야 동작한다는 것을 알게 되었습니다.
- 다음부터 조금 더 확실히 알아보고 적용할 수 있도록 하겠습니다.