### PR TITLE
fix(auth): UserDetails에 올바른 데이터가 담기지 않는 문제 해결 및 회원가입 시 권한 설정하도록 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/auth/dto/request/LoginRequestDto.java
@@ -16,9 +16,7 @@ public record LoginRequestDto(
         message = "비밀번호는 8~15자의 대소문자, 숫자, 특수문자(!@#$%^&*)를 각각 포함해야 합니다"
     )
     @Schema(description = "비밀번호(필수)", example = "Password1!")
-    String password,
-
-    String nickname
+    String password
 ) {
 
 }

--- a/src/main/java/com/sparta/tdd/domain/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/auth/dto/request/SignUpRequestDto.java
@@ -1,5 +1,6 @@
 package com.sparta.tdd.domain.auth.dto.request;
 
+import com.sparta.tdd.domain.user.enums.UserAuthority;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -18,7 +19,8 @@ public record SignUpRequestDto(
     @Schema(description = "비밀번호(필수)", example = "Password1!")
     String password,
 
-    String nickname
+    String nickname,
+    UserAuthority authority
 ) {
 
 }

--- a/src/main/java/com/sparta/tdd/global/config/JwtFilterConfig.java
+++ b/src/main/java/com/sparta/tdd/global/config/JwtFilterConfig.java
@@ -5,6 +5,7 @@ import com.sparta.tdd.global.jwt.filter.JwtAuthenticationFilter;
 import com.sparta.tdd.global.jwt.filter.JwtExceptionFilter;
 import com.sparta.tdd.global.jwt.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,6 +14,8 @@ import org.springframework.context.annotation.Configuration;
 public class JwtFilterConfig {
 
     private final ObjectMapper objectMapper;
+    
+    @Qualifier(value = "accessTokenProvider")
     private final JwtTokenProvider accessTokenProvider;
 
     @Bean

--- a/src/main/java/com/sparta/tdd/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/tdd/global/jwt/filter/JwtAuthenticationFilter.java
@@ -48,8 +48,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private UserDetailsImpl getUserDetails(String accessToken) {
         Claims claims = accessTokenProvider.getClaims(accessToken);
-        String username = claims.getSubject();
-        Long userId = claims.get("userId", Long.class);
+        Long userId = Long.valueOf(claims.getSubject());
+        String username = claims.get("username", String.class);
         UserAuthority authority = UserAuthority.valueOf(claims.get("authority", String.class));
 
         return new UserDetailsImpl(userId, username, authority);

--- a/src/test/java/com/sparta/tdd/domain/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/auth/AuthIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.sparta.tdd.domain.auth;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.tdd.domain.auth.dto.request.LoginRequestDto;
+import com.sparta.tdd.domain.auth.dto.request.SignUpRequestDto;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
+import com.sparta.tdd.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("local")
+class AuthIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원가입 후 발급받은 토큰으로 UserDetailsImpl에 올바른 데이터가 담기는지 확인")
+    void signUpAndVerifyTokenData() throws Exception {
+        // given
+        SignUpRequestDto signUpRequest = new SignUpRequestDto(
+            "testuser",
+            "Password1!",
+            "테스트유저",
+            UserAuthority.CUSTOMER
+        );
+
+        // when
+        MvcResult signUpResult = mockMvc.perform(post("/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpRequest)))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().exists("Authorization"))
+            .andReturn();
+
+        String accessToken = signUpResult.getResponse().getHeader("Authorization");
+        String bearerToken = accessToken.replace("Bearer ", "");
+
+        // then
+        mockMvc.perform(get("/v1/test/token/info")
+                .header("Authorization", "Bearer " + bearerToken))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.username").value("testuser"))
+            .andExpect(jsonPath("$.authority").value("CUSTOMER"))
+            .andExpect(jsonPath("$.userId").isNumber());
+    }
+
+    @Test
+    @DisplayName("로그인 후 발급받은 토큰으로 UserDetailsImpl에 올바른 데이터가 담기는지 확인")
+    void loginAndVerifyTokenData() throws Exception {
+        // given
+        SignUpRequestDto signUpRequest = new SignUpRequestDto(
+            "loginuser",
+            "Password1!",
+            "로그인테스트",
+            UserAuthority.MASTER
+        );
+
+        mockMvc.perform(post("/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpRequest)))
+            .andExpect(status().isOk());
+
+        LoginRequestDto loginRequest = new LoginRequestDto(
+            "loginuser",
+            "Password1!"
+        );
+
+        // when
+        MvcResult loginResult = mockMvc.perform(post("/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(header().exists("Authorization"))
+            .andReturn();
+
+        String accessToken = loginResult.getResponse().getHeader("Authorization");
+        String bearerToken = accessToken.replace("Bearer ", "");
+
+        // then
+        mockMvc.perform(get("/v1/test/token/info")
+                .header("Authorization", "Bearer " + bearerToken))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.username").value("loginuser"))
+            .andExpect(jsonPath("$.authority").value("MASTER"))
+            .andExpect(jsonPath("$.userId").isNumber());
+    }
+}

--- a/src/test/java/com/sparta/tdd/domain/auth/TestAuthController.java
+++ b/src/test/java/com/sparta/tdd/domain/auth/TestAuthController.java
@@ -1,0 +1,31 @@
+package com.sparta.tdd.domain.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/test")
+public class TestAuthController {
+
+    @GetMapping("/token/info")
+    public ResponseEntity<?> getUserDetailsInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body("인증되지 않은 사용자");
+        }
+
+        return ResponseEntity.ok(new TokenInfoResponse(
+            userDetails.getUserId(),
+            userDetails.getUsername(),
+            userDetails.getUserAuthority().name()
+        ));
+    }
+
+    public record TokenInfoResponse(
+        Long userId,
+        String username,
+        String authority
+    ) {}
+}


### PR DESCRIPTION
## PR 내용

- [refactor: 회원가입 권한 설정가능하도록 추가](https://github.com/Sparta-21/TDD/commit/588a160c71131135cc1cf511aa2ad4c908758b5a)
  - 권한별로 비즈니스 로직이 달라질 수 있어 회원가입 시 권한이 설정 가능하도록 추가

- [refactor: JwtAuthenticationFilter에서 정상적인 UserDetails 구성하도록 변경](https://github.com/Sparta-21/TDD/commit/b0987797f29d7e807ce13599832985b706972775)
  - 올바른 userId, username, authority를 구성하도록 설정

- [feat: JwtFilterConfig 내 JwtTokenProvider 명확하게 지정](https://github.com/Sparta-21/TDD/commit/73722040576b48f438c973a8cd34e1804851b558)
  - 오류가 발생하는 경우가 있어 `@Qualifier` 설정으로 명확하게 Bean 지정

- [test: UserDetailsImpl에 올바른 데이터가 담기는 통합테스트 작성](https://github.com/Sparta-21/TDD/commit/ebd85cc3480676e63655e6a1b3b0ea81a8d49559)
  - 단위테스트로 작성하기에는 시간이 조금 오래 걸린다고 판단해 테스트 전용 컨트롤러를 생성 후 통합 테스트 환경을 구성했습니다.
  - 컨트롤러에 들어온 token이 필터를 거쳐 `UserDetailsImpl`에 구성되며, 올바른 정보가 담기는지 테스트했습니다.