### PR TITLE
feat(order): createOrder 관련구성 및 order 엔티티 price 필드 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    // mapStruct
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -1,0 +1,49 @@
+package com.sparta.tdd.domain.order.controller;
+
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import com.sparta.tdd.domain.order.dto.OrderRequestDto;
+import com.sparta.tdd.domain.order.dto.OrderResponseDto;
+import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.service.OrderService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/v1/orders")
+@RequiredArgsConstructor
+@Slf4j
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderResponseDto> getOrder(@PathVariable UUID orderId) {
+        return ResponseEntity.ok(orderService.getOrder(orderId));
+    }
+
+    @PostMapping
+    public ResponseEntity<OrderResponseDto> createOrder(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestBody @Valid OrderRequestDto reqDto) {
+
+        OrderResponseDto resDto = orderService.createOrder(userDetails, reqDto);
+
+        URI location = URI.create("/v1/orders/" + resDto.id());
+
+        return ResponseEntity
+            .created(location)
+            .body(resDto);
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.tdd.domain.order.dto;
+
+import com.sparta.tdd.domain.orderMenu.dto.OrderMenuRequestDto;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.List;
+
+public record OrderRequestDto(
+    @NotBlank String address,
+    @NotBlank String customerName,
+    @NotBlank String storeName,
+    @PositiveOrZero Integer price,
+    @NotEmpty @Valid List<OrderMenuRequestDto> menu
+) {
+
+}

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.tdd.domain.order.dto;
+
+import com.sparta.tdd.domain.orderMenu.dto.OrderMenuResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderResponseDto(
+    UUID id,
+    String customerName,
+    String storeName,
+    Integer price,
+    String address,
+    List<OrderMenuResponseDto> orderMenuList,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
@@ -22,17 +22,14 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Table(name = "p_order")
-@Builder
 public class Order extends BaseEntity {
 
     @Id
@@ -41,10 +38,7 @@ public class Order extends BaseEntity {
 
     private String address;
 
-    private Integer price;
-
     @Enumerated(EnumType.STRING)
-    @Builder.Default
     private OrderStatus orderStatus = OrderStatus.PENDING;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -62,7 +56,27 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "payment_id")
     private Payment payment;
 
-    public void updatePrice(Integer price) {
-        this.price = price;
+    @Builder
+    public Order(String address, OrderStatus orderStatus, List<OrderMenu> orderMenuList,
+        Store store,
+        User user) {
+        this.address = address;
+        this.orderStatus = orderStatus;
+        this.orderMenuList = orderMenuList;
+        this.store = store;
+        this.user = user;
+    }
+
+    public void assignUser(User user) {
+        this.user = user;
+    }
+
+    public void assignStore(Store store) {
+        this.store = store;
+    }
+
+    public void addOrderMenu(OrderMenu orderMenu) {
+        this.orderMenuList.add(orderMenu);
+        orderMenu.assignOrder(this);
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/sparta/tdd/domain/order/mapper/OrderMapper.java
@@ -1,0 +1,23 @@
+package com.sparta.tdd.domain.order.mapper;
+
+import com.sparta.tdd.domain.order.dto.OrderRequestDto;
+import com.sparta.tdd.domain.order.dto.OrderResponseDto;
+import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.orderMenu.mapper.OrderMenuMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = OrderMenuMapper.class)
+public interface OrderMapper {
+
+    @Mapping(target = "orderMenuList", ignore = true)
+    @Mapping(target = "user", ignore = true)
+    @Mapping(target = "store", ignore = true)
+    Order toOrder(OrderRequestDto orderRequestDto);
+
+    @Mapping(target = "customerName", source = "user.username")
+    @Mapping(target = "storeName", source = "store.name")
+    @Mapping(target = "price",
+        expression = "java(order.getOrderMenuList().stream().mapToInt(om -> om.getPrice()).sum())")
+    OrderResponseDto toResponse(Order order);
+}

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -79,12 +79,11 @@ public class OrderService {
 
             OrderMenu orderMenu = OrderMenu.builder()
                 .quantity(om.quantity())
-                .price(om.price())     // 단가 저장으로 바꾸고 싶으면 menu.getPrice()만 넣기
+                .price(om.price())
                 .menu(menu)
                 .build();
 
             order.addOrderMenu(orderMenu);
-            orderMenu.assignMenu(menu);
         }
 
         Order savedOrder = orderRepository.save(order);

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -1,0 +1,95 @@
+package com.sparta.tdd.domain.order.service;
+
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import com.sparta.tdd.domain.menu.entity.Menu;
+import com.sparta.tdd.domain.menu.repository.MenuRepository;
+import com.sparta.tdd.domain.order.dto.OrderRequestDto;
+import com.sparta.tdd.domain.order.dto.OrderResponseDto;
+import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.mapper.OrderMapper;
+import com.sparta.tdd.domain.order.repository.OrderRepository;
+import com.sparta.tdd.domain.orderMenu.dto.OrderMenuRequestDto;
+import com.sparta.tdd.domain.orderMenu.entity.OrderMenu;
+import com.sparta.tdd.domain.store.entity.Store;
+import com.sparta.tdd.domain.store.repository.StoreRepository;
+import com.sparta.tdd.domain.user.entity.User;
+import com.sparta.tdd.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+    private final OrderMapper orderMapper;
+    private final MenuRepository menuRepository;
+
+    public OrderResponseDto getOrder(UUID orderId) {
+        return null;
+    }
+
+    public OrderResponseDto createOrder(
+        UserDetailsImpl userDetails,
+        OrderRequestDto reqDto) {
+
+        User foundUser = userRepository.findById(userDetails.getUserId())
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Store foundStore = storeRepository.findByName(reqDto.storeName())
+            .orElseThrow(() -> new IllegalArgumentException("가게이름을 찾을 수 없습니다."));
+
+        Order order = orderMapper.toOrder(reqDto);
+        order.assignUser(foundUser);
+        order.assignStore(foundStore);
+
+        List<UUID> menuIds = reqDto.menu().stream()
+            .map(OrderMenuRequestDto::menuId)
+            .toList();
+
+        List<Menu> menus = menuRepository.findAllById(menuIds);
+        Map<UUID, Menu> menuMap = menus.stream()
+                .collect(Collectors.toMap(Menu::getId, Function.identity()));
+
+        // 빠진 메뉴(존재하지 않는 menuId) 검증
+        if (menuMap.size() != menuIds.size()) {
+            // 어떤 id가 빠졌는지 알려주면 디버깅에 좋음
+            List<UUID> missing = new ArrayList<>(menuIds);
+            missing.removeAll(menuMap.keySet());
+            throw new IllegalArgumentException("존재하지 않는 메뉴가 포함되어 있습니다: " + missing);
+        }
+
+        for (OrderMenuRequestDto om : reqDto.menu()) {
+            Menu menu = menuMap.get(om.menuId());
+
+            if (!menu.getStore().getId().equals(foundStore.getId())) {
+                throw new IllegalArgumentException("해당 가게의 메뉴가 아닙니다: menuId=" + om.menuId());
+            }
+
+            OrderMenu orderMenu = OrderMenu.builder()
+                .quantity(om.quantity())
+                .price(om.price())     // 단가 저장으로 바꾸고 싶으면 menu.getPrice()만 넣기
+                .menu(menu)
+                .build();
+
+            order.addOrderMenu(orderMenu);
+            orderMenu.assignMenu(menu);
+        }
+
+        Order savedOrder = orderRepository.save(order);
+
+        OrderResponseDto resDto = orderMapper.toResponse(savedOrder);
+
+        return resDto;
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -14,7 +14,6 @@ import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,9 +22,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderService {
 
@@ -39,6 +39,7 @@ public class OrderService {
         return null;
     }
 
+    @Transactional
     public OrderResponseDto createOrder(
         UserDetailsImpl userDetails,
         OrderRequestDto reqDto) {

--- a/src/main/java/com/sparta/tdd/domain/orderMenu/dto/OrderMenuRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/orderMenu/dto/OrderMenuRequestDto.java
@@ -1,0 +1,16 @@
+package com.sparta.tdd.domain.orderMenu.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+
+public record OrderMenuRequestDto(
+    @NotNull UUID menuId,
+    @NotBlank String name,
+    @PositiveOrZero Integer price,
+    @Positive Integer quantity
+) {
+
+}

--- a/src/main/java/com/sparta/tdd/domain/orderMenu/dto/OrderMenuResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/orderMenu/dto/OrderMenuResponseDto.java
@@ -1,0 +1,12 @@
+package com.sparta.tdd.domain.orderMenu.dto;
+
+import java.util.UUID;
+
+public record OrderMenuResponseDto(
+    UUID id,
+    String name,
+    Integer price,
+    Integer quantity
+) {
+
+}

--- a/src/main/java/com/sparta/tdd/domain/orderMenu/entity/OrderMenu.java
+++ b/src/main/java/com/sparta/tdd/domain/orderMenu/entity/OrderMenu.java
@@ -19,8 +19,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Getter
 @Table(name = "p_order_menu")
 public class OrderMenu extends BaseEntity {
@@ -40,6 +38,22 @@ public class OrderMenu extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id", nullable = false)
     private Menu menu;
+
+    @Builder
+    public OrderMenu(Integer quantity, Integer price, Order order, Menu menu) {
+        this.quantity = quantity;
+        this.price = price;
+        this.order = order;
+        this.menu = menu;
+    }
+
+    public void assignOrder(Order order) {
+        this.order = order;
+    }
+
+    public void assignMenu(Menu menu) {
+        this.menu = menu;
+    }
 
     public void updateQuantity(Integer quantity) {
         this.quantity = quantity;

--- a/src/main/java/com/sparta/tdd/domain/orderMenu/mapper/OrderMenuMapper.java
+++ b/src/main/java/com/sparta/tdd/domain/orderMenu/mapper/OrderMenuMapper.java
@@ -1,0 +1,16 @@
+package com.sparta.tdd.domain.orderMenu.mapper;
+
+import com.sparta.tdd.domain.order.dto.OrderResponseDto;
+import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.orderMenu.dto.OrderMenuRequestDto;
+import com.sparta.tdd.domain.orderMenu.dto.OrderMenuResponseDto;
+import com.sparta.tdd.domain.orderMenu.entity.OrderMenu;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface OrderMenuMapper {
+
+    @Mapping(source = "menu.name", target = "name")
+    OrderMenuResponseDto toResponse(OrderMenu orderMenu);
+}

--- a/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepository.java
@@ -1,9 +1,12 @@
 package com.sparta.tdd.domain.store.repository;
 
 import com.sparta.tdd.domain.store.entity.Store;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
+
+    Optional<Store> findByName(String name);
 }

--- a/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
@@ -33,7 +33,6 @@ class OrderRepositoryTest {
         @DisplayName("ID 로 주문 조회")
         void findId() {
             Order order = Order.builder()
-                .price(1000)
                 .build();
             Order saved = orderRepository.save(order);
 
@@ -47,26 +46,21 @@ class OrderRepositoryTest {
         @DisplayName("Dirty Checking 확인")
         void update() {
             Order order = Order.builder()
-                .price(1000)
                 .build();
             Order saved = orderRepository.save(order);
 
             Order found = orderRepository.findById(saved.getId()).get();
 
-            found.updatePrice(2000);
-
             em.flush();
             em.clear();
 
             Order updated = orderRepository.findById(saved.getId()).get();
-            assertThat(updated.getPrice()).isEqualTo(2000);
         }
 
         @Test
         @DisplayName("Id 로 삭제상태 변경 확인")
         void delete() {
             Order order = Order.builder()
-                .price(1000)
                 .build();
             Order saved = orderRepository.save(order);
 

--- a/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
@@ -55,7 +55,6 @@ class OrderMenuRepositoryTest {
         em.persist(testStore);
 
         testOrder = Order.builder()
-                .price(10000)
                 .user(testUser)
                 .store(testStore)
                 .build();


### PR DESCRIPTION
feat(order):
createOrder 와 관련한 
Controller
Service
Mapper
Dto

작성하였습니다

AllArgsConstructor 와 Builder 관련 피드백 반영하여 id 값을 제외한 생성자를 만들어 Build 적용하였습니다

Order Entity 에 잘못 기입된 price 필드를 제거하였습니다

컴파일 오류나지 않는 것을 확인하였고

gradle 에 새로운 의존성인 mapstruct 추가하였습니다

테스트코드 작성시 order.price 를 사용하신 코드가 있다면 테스트가 진행되지 않으실 수 있어 확인부탁드립니다

이후 코드 작성시에는 이러한 실수가 없도록 하겠습니다 죄송합니다

이후 진행사항으로는 getOrder 작성과 함께 단위테스트 진행예정입니다