### PR TITLE
feat(store): 키워드 및 카테고리 기반 상점 검색 기능 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/menu/dto/MenuWithStoreResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/dto/MenuWithStoreResponseDto.java
@@ -1,0 +1,32 @@
+package com.sparta.tdd.domain.menu.dto;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.sparta.tdd.domain.menu.entity.QMenu;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record MenuWithStoreResponseDto(
+    UUID menuId,
+    String name,
+    String description,
+    Integer price,
+    String imageUrl,
+    Boolean isHidden,
+    UUID storeId
+) {
+
+    public static Expression<MenuWithStoreResponseDto> qConstructor(QMenu menu) {
+        return Projections.constructor(
+            MenuWithStoreResponseDto.class,
+            menu.id,
+            menu.name,
+            menu.description,
+            menu.price,
+            menu.imageUrl,
+            menu.isHidden,
+            menu.store.id
+        );
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuRepository extends JpaRepository<Menu, UUID> {
+public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
 
     List<Menu> findAllByStoreId(UUID storeId);
 

--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepositoryCustom.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.sparta.tdd.domain.menu.repository;
+
+import com.sparta.tdd.domain.menu.dto.MenuWithStoreResponseDto;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface MenuRepositoryCustom {
+
+    Map<UUID, List<MenuWithStoreResponseDto>> findByStoreIds(List<UUID> storeIds);
+}

--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.sparta.tdd.domain.menu.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.tdd.domain.menu.dto.MenuWithStoreResponseDto;
+import com.sparta.tdd.domain.menu.entity.QMenu;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MenuRepositoryImpl implements MenuRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<UUID, List<MenuWithStoreResponseDto>> findByStoreIds(List<UUID> storeIds) {
+        QMenu menu = QMenu.menu;
+
+        List<MenuWithStoreResponseDto> menus = queryFactory
+            .select(MenuWithStoreResponseDto.qConstructor(menu))
+            .from(menu)
+            .where(menu.store.id.in(storeIds))
+            .fetch();
+
+        return menus.stream()
+            .collect(Collectors.groupingBy(MenuWithStoreResponseDto::storeId));
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/tdd/domain/store/controller/StoreController.java
@@ -3,7 +3,6 @@ package com.sparta.tdd.domain.store.controller;
 import com.sparta.tdd.domain.auth.UserDetailsImpl;
 import com.sparta.tdd.domain.store.dto.StoreRequestDto;
 import com.sparta.tdd.domain.store.dto.StoreResponseDto;
-import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.store.service.StoreService;
 import jakarta.validation.Valid;
@@ -31,18 +30,17 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    // TODO: 키워드, 카테고리 기반 검색 조건 구현
-    @GetMapping("")
-    public Page<Store> getStores(
+    @GetMapping
+    public ResponseEntity<Page<StoreResponseDto>> searchStores(
         @RequestParam(required = false) String keyword,
         @RequestParam(required = false) StoreCategory storeCategory,
         Pageable pageable) {
-
-        storeService.getStores(keyword, storeCategory, pageable);
-        return null;
+        Page<StoreResponseDto> responseDto = storeService.searchStoresByKeywordAndCategoryWithMenus(
+            keyword, storeCategory, pageable);
+        return ResponseEntity.ok(responseDto);
     }
 
-    @PostMapping("")
+    @PostMapping
     public ResponseEntity<StoreResponseDto> createStore(
         @Valid @RequestBody StoreRequestDto requestDto,
         @AuthenticationPrincipal UserDetailsImpl user) {

--- a/src/main/java/com/sparta/tdd/domain/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/store/dto/StoreResponseDto.java
@@ -1,8 +1,16 @@
 package com.sparta.tdd.domain.store.dto;
 
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.sparta.tdd.domain.menu.dto.MenuWithStoreResponseDto;
+import com.sparta.tdd.domain.store.entity.QStore;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -15,10 +23,11 @@ public record StoreResponseDto(
     String description,
     String imageUrl,
     BigDecimal avgRating,
-    Integer reviewCount
+    Integer reviewCount,
+    List<MenuWithStoreResponseDto> menus
 ) {
 
-    public static StoreResponseDto of(Store store) {
+    public static StoreResponseDto from(Store store) {
         return StoreResponseDto.builder()
             .id(store.getId())
             .name(store.getName())
@@ -28,6 +37,36 @@ public record StoreResponseDto(
             .imageUrl(store.getImageUrl())
             .avgRating(store.getAvgRating())
             .reviewCount(store.getReviewCount())
+            .build();
+    }
+
+    public static Expression<StoreResponseDto> qConstructor(QStore store) {
+        return Projections.constructor(
+            StoreResponseDto.class,
+            store.id,
+            store.name,
+            store.user.username,
+            store.category,
+            store.description,
+            store.imageUrl,
+            store.avgRating,
+            store.reviewCount,
+            ExpressionUtils.as(Expressions.constant(new ArrayList<MenuWithStoreResponseDto>()),
+                "menus")
+        );
+    }
+
+    public StoreResponseDto withMenus(List<MenuWithStoreResponseDto> newMenus) {
+        return StoreResponseDto.builder()
+            .id(this.id)
+            .name(this.name)
+            .ownerName(this.ownerName)
+            .category(this.category)
+            .description(this.description)
+            .imageUrl(this.imageUrl)
+            .avgRating(this.avgRating)
+            .reviewCount(this.reviewCount)
+            .menus(newMenus)
             .build();
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/tdd/domain/store/entity/Store.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,9 +29,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "p_store")
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseEntity {
 
     @Id
@@ -53,13 +50,11 @@ public class Store extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
-    @Builder.Default
     @Column(name = "avg_rating", precision = 2, scale = 1)
-    private BigDecimal avgRating = BigDecimal.ZERO;
+    private BigDecimal avgRating;
 
-    @Builder.Default
     @Column(name = "review_count")
-    private Integer reviewCount = 0;
+    private Integer reviewCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -67,6 +62,19 @@ public class Store extends BaseEntity {
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Menu> menuList = new ArrayList<>();
+
+    @Builder
+    public Store(String name, StoreCategory category, String description, String imageUrl,
+        User user, List<Menu> menuList) {
+        this.name = name;
+        this.category = category;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.avgRating = BigDecimal.ZERO;
+        this.reviewCount = 0;
+        this.user = user;
+        this.menuList = menuList;
+    }
 
     public void updateName(String updatedName) {
         this.name = updatedName;

--- a/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepository.java
@@ -7,10 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface StoreRepository extends JpaRepository<Store, UUID> {
+public interface StoreRepository extends JpaRepository<Store, UUID>, StoreRepositoryCustom {
 
     @Query("SELECT s FROM Store s WHERE s.id = :storeId AND s.deletedAt IS NULL")
     Optional<Store> findByStoreIdAndNotDeleted(@Param("storeId") UUID storeId);
-  
+
     Optional<Store> findByName(String name);
 }

--- a/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.sparta.tdd.domain.store.repository;
+
+import com.sparta.tdd.domain.store.dto.StoreResponseDto;
+import com.sparta.tdd.domain.store.enums.StoreCategory;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface StoreRepositoryCustom {
+
+    List<UUID> findStoreIdsByMenuKeyword(String keyword, StoreCategory storeCategory);
+
+    List<UUID> findStoreIdsByStoreNameKeyword(String keyword, StoreCategory storeCategory);
+
+    Page<StoreResponseDto> findStoresByIds(List<UUID> storeIds, Pageable pageable);
+}

--- a/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.sparta.tdd.domain.store.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.tdd.domain.menu.entity.QMenu;
+import com.sparta.tdd.domain.store.dto.StoreResponseDto;
+import com.sparta.tdd.domain.store.entity.QStore;
+import com.sparta.tdd.domain.store.enums.StoreCategory;
+import com.sparta.tdd.domain.user.entity.QUser;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class StoreRepositoryImpl implements StoreRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UUID> findStoreIdsByMenuKeyword(String keyword, StoreCategory storeCategory) {
+        QStore store = new QStore("store");
+        QMenu menu = new QMenu("menu");
+
+        BooleanBuilder builder = buildStoreFilter(keyword, storeCategory, false);
+
+        return queryFactory
+            .select(store.id)
+            .from(menu)
+            .join(menu.store, store)
+            .where(builder)
+            .fetch();
+    }
+
+    @Override
+    public List<UUID> findStoreIdsByStoreNameKeyword(String keyword, StoreCategory storeCategory) {
+        QStore store = QStore.store;
+
+        BooleanBuilder builder = buildStoreFilter(keyword, storeCategory, true);
+
+        return queryFactory
+            .select(store.id)
+            .from(store)
+            .where(builder)
+            .fetch();
+    }
+
+    @Override
+    public Page<StoreResponseDto> findStoresByIds(List<UUID> storeIds, Pageable pageable) {
+        QStore store = QStore.store;
+        QUser user = QUser.user;
+
+        List<StoreResponseDto> stores = queryFactory
+            .select(StoreResponseDto.qConstructor(store))
+            .from(store)
+            .leftJoin(store.user, user)
+            .where(store.id.in(storeIds))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(store.count())
+            .from(store)
+            .where(store.id.in(storeIds));
+
+        return PageableExecutionUtils.getPage(stores, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanBuilder buildStoreFilter(String keyword, StoreCategory storeCategory,
+        boolean includeStoreName) {
+        QStore store = QStore.store;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (includeStoreName && keyword != null && !keyword.isBlank()) {
+            builder.and(store.name.containsIgnoreCase(keyword));
+        }
+
+        if (storeCategory != null) {
+            builder.and(store.category.eq(storeCategory));
+        }
+
+        return builder;
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/tdd/domain/user/entity/User.java
@@ -1,6 +1,5 @@
 package com.sparta.tdd.domain.user.entity;
 
-import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.global.model.BaseEntity;
 import jakarta.persistence.Column;
@@ -10,11 +9,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,14 +46,6 @@ public class User extends BaseEntity {
         this.password = password;
         this.nickname = nickname;
         this.authority = authority;
-    }
-
-    @OneToMany(mappedBy = "user")
-    private List<Store> stores = new ArrayList<>();
-
-    public void addStore(Store store) {
-        this.stores.add(store);
-        store.updateUser(this);
     }
 
     public boolean isOwnerLevel() {

--- a/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryTest.java
@@ -1,11 +1,17 @@
 package com.sparta.tdd.domain.store.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.global.config.AuditConfig;
 import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,13 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @Import(AuditConfig.class)
@@ -37,11 +36,11 @@ class StoreRepositoryTest {
     @BeforeEach
     void setUp() {
         testUser = User.builder()
-                .username("testuser")
-                .password("password123")
-                .nickname("테스트유저")
-                .authority(UserAuthority.CUSTOMER)
-                .build();
+            .username("testuser")
+            .password("password123")
+            .nickname("테스트유저")
+            .authority(UserAuthority.CUSTOMER)
+            .build();
         em.persist(testUser);
         em.flush();
         em.clear();
@@ -53,12 +52,12 @@ class StoreRepositoryTest {
         //given
         User user = em.find(User.class, testUser.getId());
         Store chickenStore = Store.builder()
-                .name("BBQ")
-                .category(StoreCategory.CHICKEN)
-                .description("BBQ 광화문점")
-                .imageUrl("www.test.com")
-                .user(user)
-                .build();
+            .name("BBQ")
+            .category(StoreCategory.CHICKEN)
+            .description("BBQ 광화문점")
+            .imageUrl("www.test.com")
+            .user(user)
+            .build();
 
         Store savedStore = storeRepository.save(chickenStore);
         storeRepository.flush();
@@ -85,22 +84,20 @@ class StoreRepositoryTest {
         User user = em.find(User.class, testUser.getId());
 
         Store chickenStore = Store.builder()
-                .name("BBQ")
-                .category(StoreCategory.CHICKEN)
-                .description("BBQ 광화문점")
-                .imageUrl("www.test.com")
-                .user(user)
-                .build();
+            .name("BBQ")
+            .category(StoreCategory.CHICKEN)
+            .description("BBQ 광화문점")
+            .imageUrl("www.test.com")
+            .user(user)
+            .build();
 
         Store pizzaStore = Store.builder()
-                .name("도미노피자")
-                .category(StoreCategory.PIZZA)
-                .description("도미노피자 광화문점")
-                .imageUrl("www.test.com")
-                .avgRating(BigDecimal.valueOf(4.0))
-                .reviewCount(3)
-                .user(user)
-                .build();
+            .name("도미노피자")
+            .category(StoreCategory.PIZZA)
+            .description("도미노피자 광화문점")
+            .imageUrl("www.test.com")
+            .user(user)
+            .build();
 
         storeRepository.save(chickenStore);
         storeRepository.save(pizzaStore);
@@ -112,9 +109,9 @@ class StoreRepositoryTest {
         // then
         assertEquals(2, stores.size(), "저장된 Store 개수와 조회된 개수가 일치해야 한다.");
         assertTrue(stores.stream()
-                .anyMatch(s -> s.getName().equals("BBQ")));
+            .anyMatch(s -> s.getName().equals("BBQ")));
         assertTrue(stores.stream()
-                .anyMatch(s -> s.getName().equals("도미노피자")));
+            .anyMatch(s -> s.getName().equals("도미노피자")));
     }
 
     @Test
@@ -123,12 +120,12 @@ class StoreRepositoryTest {
         //given
         User user = em.find(User.class, testUser.getId());
         Store chickenStore = Store.builder()
-                .name("BBQ")
-                .category(StoreCategory.CHICKEN)
-                .description("BBQ 광화문점")
-                .imageUrl("www.test.com")
-                .user(user)
-                .build();
+            .name("BBQ")
+            .category(StoreCategory.CHICKEN)
+            .description("BBQ 광화문점")
+            .imageUrl("www.test.com")
+            .user(user)
+            .build();
 
         Store savedStore = storeRepository.save(chickenStore);
         storeRepository.flush();


### PR DESCRIPTION
[refactor(user): User, Store 양방향 관계 제거](https://github.com/Sparta-21/TDD/commit/5caab72f9d2762b7ac96d9836baf5e972b82051b)
[refactor(user): user 식별자 생성자 제거](https://github.com/Sparta-21/TDD/commit/2cfbf1e1aa67156239d051f4e568f947541c70b8)
- 튜터님 피드백 반영

[feat(store): StoreResponseDto에 qConstructor 및 withMenus 메서드 추가](https://github.com/Sparta-21/TDD/commit/59f5a5ed3c7590e8c5bb46722c1d73a85f029b10)
[feat(menu): MenuWithStoreResponseDto qConstructor 및 코드 추가](https://github.com/Sparta-21/TDD/commit/c110a45ff608630767673a75631439c7b8ca7a28)
- QueryDSL Projections용 qConstructor 메서드 구현
- 불변 객체에 메뉴 리스트를 추가할 수 있는 withMenus 메서드 제공

[feat(menu): MenuRepositoryImpl, MenuRepositoryCustom 코드 추가](https://github.com/Sparta-21/TDD/commit/5037051fb4d36dd847588b34234b0633594bbaef)


[feat(store): 키워드 및 카테고리 기반 상점 검색 기능 추가](https://github.com/Sparta-21/TDD/commit/fa3447bfccafac2c6fc7b4693be8169c7f7299fd)
[feat(menu): MenuRepositoryImpl, MenuRepositoryCustom 코드 추가](https://github.com/Sparta-21/TDD/commit/5037051fb4d36dd847588b34234b0633594bbaef)

- 메뉴 이름으로 상점 검색: findStoreIdsByMenuKeyword
- 상점 이름으로 상점 검색: findStoreIdsByStoreNameKeyword
- 상점 ID 리스트 기반 페이징 조회: findStoresByIds
- BooleanBuilder 공통화 메서드 buildStoreFilter 추가

## TODO : 검색 시 정렬 기능(별점 순)