### PR TITLE
feat(order): 주문상세조회, 기간, userId, storeId 로 검색가능한 주문전체조회 기능 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -3,16 +3,25 @@ package com.sparta.tdd.domain.order.controller;
 import com.sparta.tdd.domain.auth.UserDetailsImpl;
 import com.sparta.tdd.domain.order.dto.OrderRequestDto;
 import com.sparta.tdd.domain.order.dto.OrderResponseDto;
+import com.sparta.tdd.domain.order.dto.OrderSearchOptionDto;
 import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,20 +37,46 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    // 동적검색이 가능해야 한다
+    @GetMapping
+    public ResponseEntity<Page<OrderResponseDto>> getOrders(
+        @ModelAttribute @Valid OrderSearchOptionDto searchOption,
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PageableDefault Pageable pageable) {
+        log.info("Controller.getOrders 요청 수신");
+
+        Page<OrderResponseDto> responseDtos = orderService.getOrders(
+            userDetails.getUserId(),
+            pageable,
+            searchOption
+        );
+
+        log.info("Controller.getOrders 요청 종료");
+        return ResponseEntity.ok(responseDtos);
+    }
+
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderResponseDto> getOrder(@PathVariable UUID orderId) {
-        return ResponseEntity.ok(orderService.getOrder(orderId));
+    public ResponseEntity<OrderResponseDto> getOrder(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable UUID orderId) {
+        log.info("Controller.getOrder 요청수신");
+
+        OrderResponseDto responseDto = orderService.getOrder(userDetails.getUserId(), orderId);
+
+        log.info("Controller.getOrder 요청 종료");
+        return ResponseEntity.ok(responseDto);
     }
 
     @PostMapping
     public ResponseEntity<OrderResponseDto> createOrder(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestBody @Valid OrderRequestDto reqDto) {
-
+        log.info("Controller.createOrder 요청수신");
         OrderResponseDto resDto = orderService.createOrder(userDetails.getUserId(), reqDto);
 
         URI location = URI.create("/v1/orders/" + resDto.id());
 
+        log.info("Controller.createOrder 요청종료, Created URI: {}, ", location);
         return ResponseEntity
             .created(location)
             .body(resDto);

--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -4,20 +4,15 @@ import com.sparta.tdd.domain.auth.UserDetailsImpl;
 import com.sparta.tdd.domain.order.dto.OrderRequestDto;
 import com.sparta.tdd.domain.order.dto.OrderResponseDto;
 import com.sparta.tdd.domain.order.dto.OrderSearchOptionDto;
-import com.sparta.tdd.domain.order.entity.Order;
-import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,7 +41,7 @@ public class OrderController {
         log.info("Controller.getOrders 요청 수신");
 
         Page<OrderResponseDto> responseDtos = orderService.getOrders(
-            userDetails.getUserId(),
+            userDetails,
             pageable,
             searchOption
         );
@@ -61,7 +56,10 @@ public class OrderController {
         @PathVariable UUID orderId) {
         log.info("Controller.getOrder 요청수신");
 
-        OrderResponseDto responseDto = orderService.getOrder(userDetails.getUserId(), orderId);
+        OrderResponseDto responseDto = orderService.getOrder(
+            userDetails,
+            orderId
+        );
 
         log.info("Controller.getOrder 요청 종료");
         return ResponseEntity.ok(responseDto);
@@ -72,7 +70,10 @@ public class OrderController {
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestBody @Valid OrderRequestDto reqDto) {
         log.info("Controller.createOrder 요청수신");
-        OrderResponseDto resDto = orderService.createOrder(userDetails.getUserId(), reqDto);
+        OrderResponseDto resDto = orderService.createOrder(
+            userDetails,
+            reqDto
+        );
 
         URI location = URI.create("/v1/orders/" + resDto.id());
 

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderResponseDto.java
@@ -1,5 +1,8 @@
 package com.sparta.tdd.domain.order.dto;
 
+import static com.sparta.tdd.domain.order.enums.OrderStatus.PENDING;
+
+import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.orderMenu.dto.OrderMenuResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +15,7 @@ public record OrderResponseDto(
     Integer price,
     String address,
     List<OrderMenuResponseDto> orderMenuList,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    OrderStatus orderStatus
 ) {
 }

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderSearchOptionDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderSearchOptionDto.java
@@ -1,7 +1,6 @@
 package com.sparta.tdd.domain.order.dto;
 
 import com.sparta.tdd.domain.order.enums.OrderStatus;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -14,10 +13,9 @@ public record OrderSearchOptionDto(
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     LocalDate to,
 
-    OrderStatus status,
-
-    @NotNull
     Long userId,
+
+    OrderStatus status,
 
     UUID storeId
 ) {

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderSearchOptionDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderSearchOptionDto.java
@@ -1,0 +1,33 @@
+package com.sparta.tdd.domain.order.dto;
+
+import com.sparta.tdd.domain.order.enums.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record OrderSearchOptionDto(
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    LocalDate from,
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    LocalDate to,
+
+    OrderStatus status,
+
+    @NotNull
+    Long userId,
+
+    UUID storeId
+) {
+
+    public LocalDateTime startOrNull() {
+        return (from != null) ? from.atStartOfDay() : null;
+    }
+
+    public LocalDateTime endOrNull() {
+        return (to != null) ? to.plusDays(1).atStartOfDay() : null;
+    }
+
+}

--- a/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
@@ -7,6 +7,7 @@ import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.global.model.BaseEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -36,10 +37,11 @@ public class Order extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(nullable = false)
     private String address;
 
     @Enumerated(EnumType.STRING)
-    private OrderStatus orderStatus = OrderStatus.PENDING;
+    private OrderStatus orderStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -50,7 +52,7 @@ public class Order extends BaseEntity {
     private Store store;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<OrderMenu> orderMenuList = new ArrayList<>();
+    private List<OrderMenu> orderMenuList;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payment_id")
@@ -61,7 +63,7 @@ public class Order extends BaseEntity {
         Store store,
         User user) {
         this.address = address;
-        this.orderStatus = orderStatus;
+        this.orderStatus = (orderStatus != null) ? orderStatus : OrderStatus.PENDING;
         this.orderMenuList = orderMenuList != null ? orderMenuList : new ArrayList<>();
         this.store = store;
         this.user = user;

--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
@@ -1,12 +1,9 @@
 package com.sparta.tdd.domain.order.repository;
 
 import com.sparta.tdd.domain.order.entity.Order;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -26,13 +23,13 @@ public interface OrderRepository extends JpaRepository<Order, UUID>, OrderReposi
 //        """)
 //    Optional<Order> findDetailById(UUID id);
 
-    @Query("""
-          select o.id
-          from Order o
-          order by o.createdAt desc
-        """)
-    Page<UUID> findPageIds(Pageable pageable, Long targetUserId, LocalDateTime start,
-        LocalDateTime end, UUID targetStoreId);
+//    @Query("""
+//          select o.id
+//          from Order o
+//          order by o.createdAt desc
+//        """)
+//    Page<UUID> findPageIds(Pageable pageable, Long targetUserId, LocalDateTime start,
+//        LocalDateTime end, UUID targetStoreId);
 
     @Query("""
           select distinct o

--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
@@ -16,36 +16,16 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OrderRepository extends JpaRepository<Order, UUID>, OrderRepositoryCustom {
 
-//    @Query("""
-//            select distinct o
-//            from Order o
-//            left join fetch o.user u
-//            left join fetch o.store s
-//            left join fetch o.payment p
-//            left join fetch o.orderMenuList om
-//            left join fetch om.menu m
-//            where o.id = :id
-//        """)
-//    Optional<Order> findDetailById(UUID id);
-
     @Modifying
     @Query("UPDATE Order o SET o.deletedAt = :deletedAt, o.deletedBy = :deletedBy WHERE o.user.id = :userId AND o.deletedAt IS NULL")
     void bulkSoftDeleteByUserId(
-        @Param("userId") Long userId,
-        @Param("deletedAt") LocalDateTime deletedAt,
-        @Param("deletedBy") Long deletedBy
+            @Param("userId") Long userId,
+            @Param("deletedAt") LocalDateTime deletedAt,
+            @Param("deletedBy") Long deletedBy
     );
 
     @Query("SELECT o.id FROM Order o WHERE o.user.id = :userId AND o.deletedAt IS NULL")
     List<UUID> findOrderIdsByUserIdAndDeletedAtIsNull(Long userId);
-
-//    @Query("""
-//          select o.id
-//          from Order o
-//          order by o.createdAt desc
-//        """)
-//    Page<UUID> findPageIds(Pageable pageable, Long targetUserId, LocalDateTime start,
-//        LocalDateTime end, UUID targetStoreId);
 
     @Query("""
           select distinct o
@@ -59,3 +39,28 @@ public interface OrderRepository extends JpaRepository<Order, UUID>, OrderReposi
         """)
     List<Order> findDetailsByIdIn(Collection<UUID> ids);
 }
+
+
+// ---- 아래의 코드는 쿼리DSL로 대체됨 ----
+// 쿼리DSL 관련해서 수정중 문제가 생기면 아래의 JPQL 로 대체하기 위하여 남겨놨습니다
+// 이후 order 와 관련된 내용들이 구현 완료되고 안정화 되면 삭제하도록 하겠습니다
+
+//    @Query("""
+//            select distinct o
+//            from Order o
+//            left join fetch o.user u
+//            left join fetch o.store s
+//            left join fetch o.payment p
+//            left join fetch o.orderMenuList om
+//            left join fetch om.menu m
+//            where o.id = :id
+//        """)
+//    Optional<Order> findDetailById(UUID id);
+
+//    @Query("""
+//          select o.id
+//          from Order o
+//          order by o.createdAt desc
+//        """)
+//    Page<UUID> findPageIds(Pageable pageable, Long targetUserId, LocalDateTime start,
+//        LocalDateTime end, UUID targetStoreId);

--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
@@ -1,11 +1,48 @@
 package com.sparta.tdd.domain.order.repository;
 
 import com.sparta.tdd.domain.order.entity.Order;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OrderRepository extends JpaRepository<Order, UUID> {
+public interface OrderRepository extends JpaRepository<Order, UUID>, OrderRepositoryCustom {
 
+//    @Query("""
+//            select distinct o
+//            from Order o
+//            left join fetch o.user u
+//            left join fetch o.store s
+//            left join fetch o.payment p
+//            left join fetch o.orderMenuList om
+//            left join fetch om.menu m
+//            where o.id = :id
+//        """)
+//    Optional<Order> findDetailById(UUID id);
+
+    @Query("""
+          select o.id
+          from Order o
+          order by o.createdAt desc
+        """)
+    Page<UUID> findPageIds(Pageable pageable, Long targetUserId, LocalDateTime start,
+        LocalDateTime end, UUID targetStoreId);
+
+    @Query("""
+          select distinct o
+          from Order o
+          left join fetch o.user
+          left join fetch o.store
+          left join fetch o.payment
+          left join fetch o.orderMenuList om
+          left join fetch om.menu m
+          where o.id in :ids
+        """)
+    List<Order> findDetailsByIdIn(Collection<UUID> ids);
 }

--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.sparta.tdd.domain.order.repository;
+
+import com.sparta.tdd.domain.order.entity.Order;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrderRepositoryCustom {
+    Optional<Order> findDetailById(UUID id);
+}

--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepositoryCustom.java
@@ -1,9 +1,31 @@
 package com.sparta.tdd.domain.order.repository;
 
 import com.sparta.tdd.domain.order.entity.Order;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderRepositoryCustom {
+
+
     Optional<Order> findDetailById(UUID id);
+
+    /**
+     * 검색, 정렬과 페이징 조건에 맞는 orderId 를 반환합니다
+     * @param pageable
+     * @param targetUserId
+     * @param start
+     * @param end
+     * @param targetStoreId
+     * @return return new PageImpl<>(ids, pageable, total);
+     */
+    Page<UUID> findPageIds(
+        Pageable pageable,
+        Long targetUserId,
+        LocalDateTime start,
+        LocalDateTime end,
+        UUID targetStoreId);
+
 }

--- a/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.sparta.tdd.domain.order.repository.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.tdd.domain.menu.entity.QMenu;
+import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.entity.QOrder;
+import com.sparta.tdd.domain.order.repository.OrderRepositoryCustom;
+import com.sparta.tdd.domain.orderMenu.entity.QOrderMenu;
+import com.sparta.tdd.domain.payment.entity.QPayment;
+import com.sparta.tdd.domain.store.entity.QStore;
+import com.sparta.tdd.domain.user.entity.QUser;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public Optional<Order> findDetailById(UUID id) {
+        QOrder o = QOrder.order;
+        QUser u = QUser.user;
+        QStore s = QStore.store;
+        QPayment p = QPayment.payment;
+        QOrderMenu om = QOrderMenu.orderMenu;
+        QMenu m = QMenu.menu;
+
+        Order result = query
+            .selectFrom(o)
+            .distinct()
+            .leftJoin(o.user, u).fetchJoin()
+            .leftJoin(o.store, s).fetchJoin()
+            .leftJoin(o.payment, p).fetchJoin()
+            .leftJoin(o.orderMenuList, om).fetchJoin()
+             .leftJoin(om.menu, m).fetchJoin()
+            .where(o.id.eq(id))
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.sparta.tdd.domain.order.repository.querydsl;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.tdd.domain.menu.entity.QMenu;
 import com.sparta.tdd.domain.order.entity.Order;
@@ -9,9 +10,16 @@ import com.sparta.tdd.domain.orderMenu.entity.QOrderMenu;
 import com.sparta.tdd.domain.payment.entity.QPayment;
 import com.sparta.tdd.domain.store.entity.QStore;
 import com.sparta.tdd.domain.user.entity.QUser;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @RequiredArgsConstructor
 public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
@@ -34,10 +42,80 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
             .leftJoin(o.store, s).fetchJoin()
             .leftJoin(o.payment, p).fetchJoin()
             .leftJoin(o.orderMenuList, om).fetchJoin()
-             .leftJoin(om.menu, m).fetchJoin()
+            .leftJoin(om.menu, m).fetchJoin()
             .where(o.id.eq(id))
             .fetchOne();
 
         return Optional.ofNullable(result);
     }
+
+    @Override
+    public Page<UUID> findPageIds(
+        Pageable pageable,
+        Long targetUserId,
+        LocalDateTime start,
+        LocalDateTime end,
+        UUID targetStoreId) {
+
+        QOrder o = QOrder.order;
+
+        List<UUID> ids = query
+            .select(o.id)
+            .from(o)
+            .where(
+                o.user.id.eq(targetUserId),
+                o.store.id.eq(targetStoreId),
+                o.createdAt.goe(start),
+                o.createdAt.lt(end)
+            )
+            .orderBy(toOrderSpecifier(pageable.getSort(), o))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = query
+            .select(o.count())
+            .from(o)
+            .where(
+                o.user.id.eq(targetUserId),
+                o.store.id.eq(targetStoreId),
+                o.createdAt.goe(start),
+                o.createdAt.lt(end)
+            )
+            .fetchOne();
+
+        if (total == null) {
+            total = 0L;
+        }
+
+        return new PageImpl<>(ids, pageable, total);
+    }
+
+    private OrderSpecifier<?>[] toOrderSpecifier(Sort sort, QOrder o) {
+        if (sort == null || sort.isUnsorted()) {
+            return new OrderSpecifier[]{ o.createdAt.desc() };
+        }
+
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+        for (Sort.Order sort_order : sort) {
+
+            com.querydsl.core.types.Order direction =
+                sort_order.isAscending() ?
+                    com.querydsl.core.types.Order.ASC : com.querydsl.core.types.Order.DESC;
+
+
+            switch (sort_order.getProperty()) {
+                case "createdAt" -> specifiers.add(new OrderSpecifier<>(direction, o.createdAt));
+                case "id" -> specifiers.add(new OrderSpecifier<>(direction, o.id));
+                case "orderStatus" -> specifiers.add(new OrderSpecifier<>(direction, o.orderStatus));
+                default -> {
+
+                }
+            }
+        }
+
+        return specifiers.toArray(new OrderSpecifier[0]);
+    }
+
+
 }

--- a/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
@@ -28,22 +28,22 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 
     @Override
     public Optional<Order> findDetailById(UUID id) {
-        QOrder o = QOrder.order;
-        QUser u = QUser.user;
-        QStore s = QStore.store;
-        QPayment p = QPayment.payment;
-        QOrderMenu om = QOrderMenu.orderMenu;
-        QMenu m = QMenu.menu;
+        QOrder qOrder = QOrder.order;
+        QUser qUser = QUser.user;
+        QStore qStore = QStore.store;
+        QPayment qPayment = QPayment.payment;
+        QOrderMenu qOrderMenu = QOrderMenu.orderMenu;
+        QMenu qMenu = QMenu.menu;
 
         Order result = query
-            .selectFrom(o)
+            .selectFrom(qOrder)
             .distinct()
-            .leftJoin(o.user, u).fetchJoin()
-            .leftJoin(o.store, s).fetchJoin()
-            .leftJoin(o.payment, p).fetchJoin()
-            .leftJoin(o.orderMenuList, om).fetchJoin()
-            .leftJoin(om.menu, m).fetchJoin()
-            .where(o.id.eq(id))
+            .leftJoin(qOrder.user, qUser).fetchJoin()
+            .leftJoin(qOrder.store, qStore).fetchJoin()
+            .leftJoin(qOrder.payment, qPayment).fetchJoin()
+            .leftJoin(qOrder.orderMenuList, qOrderMenu).fetchJoin()
+            .leftJoin(qOrderMenu.menu, qMenu).fetchJoin()
+            .where(qOrder.id.eq(id))
             .fetchOne();
 
         return Optional.ofNullable(result);
@@ -97,14 +97,14 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
         }
 
         List<OrderSpecifier<?>> specifiers = new ArrayList<>();
-        for (Sort.Order sort_order : sort) {
+        for (Sort.Order sortOrder : sort) {
 
             com.querydsl.core.types.Order direction =
-                sort_order.isAscending() ?
+                sortOrder.isAscending() ?
                     com.querydsl.core.types.Order.ASC : com.querydsl.core.types.Order.DESC;
 
 
-            switch (sort_order.getProperty()) {
+            switch (sortOrder.getProperty()) {
                 case "createdAt" -> specifiers.add(new OrderSpecifier<>(direction, o.createdAt));
                 case "id" -> specifiers.add(new OrderSpecifier<>(direction, o.id));
                 case "orderStatus" -> specifiers.add(new OrderSpecifier<>(direction, o.orderStatus));

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -106,12 +106,7 @@ public class OrderService {
                 .collect(Collectors.toMap(Menu::getId, Function.identity()));
 
         // 빠진 메뉴(존재하지 않는 menuId) 검증
-        if (menuMap.size() != menuIds.size()) {
-            // 어떤 id가 빠졌는지 알려주면 디버깅에 좋음
-            List<UUID> missing = new ArrayList<>(menuIds);
-            missing.removeAll(menuMap.keySet());
-            throw new IllegalArgumentException("존재하지 않는 메뉴가 포함되어 있습니다: " + missing);
-        }
+        verifyOrderMenus(menuMap, menuIds);
 
         for (OrderMenuRequestDto om : reqDto.menu()) {
             Menu menu = menuMap.get(om.menuId());
@@ -135,4 +130,20 @@ public class OrderService {
 
         return resDto;
     }
+
+    /**
+     * Dto 와 repository 조회 결과를 비교해서 누락된 메뉴가 있는지 검증
+     * @param menuMap repository 에서 조회된 menuId, Menu map
+     * @param menuIds Dto 에서 넘어온 menuId 들
+     */
+    private static void verifyOrderMenus(Map<UUID, Menu> menuMap, List<UUID> menuIds) {
+        if (menuMap.size() != menuIds.size()) {
+            // 어떤 id가 빠졌는지 알려주면 디버깅에 좋음
+            List<UUID> missing = new ArrayList<>(menuIds);
+            missing.removeAll(menuMap.keySet());
+            throw new IllegalArgumentException("존재하지 않는 메뉴가 포함되어 있습니다: " + missing);
+        }
+    }
+
+
 }

--- a/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
@@ -5,13 +5,11 @@ import static com.sparta.tdd.domain.user.enums.UserAuthority.CUSTOMER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
 import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.order.entity.Order;
 import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.orderMenu.entity.OrderMenu;
-import com.sparta.tdd.domain.payment.entity.Payment;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.global.config.AuditConfig;
@@ -28,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
@@ -1,11 +1,26 @@
 package com.sparta.tdd.domain.order.repository;
 
+import static com.sparta.tdd.domain.store.enums.StoreCategory.CHINESE;
+import static com.sparta.tdd.domain.user.enums.UserAuthority.CUSTOMER;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
+import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.enums.OrderStatus;
+import com.sparta.tdd.domain.orderMenu.entity.OrderMenu;
+import com.sparta.tdd.domain.payment.entity.Payment;
+import com.sparta.tdd.domain.store.entity.Store;
+import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.global.config.AuditConfig;
+import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnitUtil;
+import java.util.ArrayList;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,10 +28,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(AuditConfig.class)
+@Import({AuditConfig.class, QueryDSLConfig.class})
 class OrderRepositoryTest {
 
     @Autowired
@@ -71,5 +87,115 @@ class OrderRepositoryTest {
             assertThat(orderRepository.findById(saved.getId())).isPresent();
             assertThat(found.getDeletedBy()).isEqualTo(11L);
         }
+    }
+
+    @Test
+    void findDetailById_fetchJoin_graphLoaded() throws JsonProcessingException {
+        // === given ===
+        // 1) 기초 엔티티 persist
+        User user = User.builder()
+            .username("tester")
+            .password("pw")
+            .nickname("nick")
+            .authority(CUSTOMER)
+            .build();
+
+        Store store = Store.builder()
+            .name("치킨집")
+            .description("맛집")
+            .category(CHINESE)
+            .user(user).build();
+
+        em.persist(user);
+        em.persist(store);
+
+        Menu fried = Menu.builder()
+            .dto(new MenuRequestDto("후라이드", "바삭", 15_000, null))
+            .store(store)
+            .build();
+
+        Menu seasoned = Menu.builder()
+            .dto(new MenuRequestDto("양념치킨", "매콤", 16_000, null))
+            .store(store)
+            .build();
+
+        em.persist(fried);
+        em.persist(seasoned);
+
+        // 2) Order + OrderMenu 구성 (양방향 고정)
+        Order order = Order.builder()
+            .address("서울시 강남구")
+            .orderStatus(OrderStatus.PENDING)
+            .orderMenuList(new ArrayList<>())
+            .store(store)
+            .user(user)
+            .build();
+
+        OrderMenu om1 = OrderMenu.builder()
+            .menu(fried)
+            .quantity(2)
+            .price(fried.getPrice())
+            .build();
+        OrderMenu om2 = OrderMenu.builder()
+            .menu(seasoned)
+            .quantity(3)
+            .price(seasoned.getPrice())
+            .build();
+
+        order.addOrderMenu(om1);
+        order.addOrderMenu(om2);
+
+        em.persist(order);
+        em.flush();
+        em.clear(); // ★ 1차 캐시 제거: fetch join 효과를 순수 쿼리로 검증
+
+        UUID orderId = orderRepository
+            .findAll() // 단 하나니까 이렇게 꺼내도 됨 (혹은 위에서 order.getId() 보관)
+            .get(0)
+            .getId();
+
+        // === when ===
+        Order found = orderRepository.findDetailById(orderId).orElseThrow();
+
+        // === then ===
+        PersistenceUnitUtil util = em.getEntityManagerFactory().getPersistenceUnitUtil();
+
+        System.out.println("=== Order 확인 ===");
+        System.out.println("orderId   = " + found.getId());
+        System.out.println("address   = " + found.getAddress());
+        System.out.println("status    = " + found.getOrderStatus());
+        System.out.println("user      = " + (found.getUser() != null ? found.getUser().getNickname() : null));
+        System.out.println("store     = " + (found.getStore() != null ? found.getStore().getName() : null));
+        System.out.println("payment   = " + (found.getPayment() != null ? found.getPayment().getId() : null));
+
+        System.out.println("=== OrderMenu 목록 ===");
+        for (OrderMenu om : found.getOrderMenuList()) {
+            System.out.println(
+                "  menu=" + om.getMenu().getName() +
+                    ", price=" + om.getPrice() +
+                    ", qty=" + om.getQuantity()
+            );
+        }
+
+
+        // 연관 로딩 검증
+        assertThat(util.isLoaded(found.getUser())).isTrue();
+        assertThat(util.isLoaded(found.getStore())).isTrue();
+        assertThat(util.isLoaded(found.getPayment())).isTrue();
+        assertThat(util.isLoaded(found.getOrderMenuList())).isTrue();
+
+        assertThat(found.getOrderMenuList()).hasSize(2);
+
+        // 하위 연관(menu)까지 fetch join 되었는지 검증
+        OrderMenu first = found.getOrderMenuList().get(0);
+        assertThat(util.isLoaded(first.getMenu())).isTrue();
+
+        // 값도 간단히 검증
+        assertThat(found.getAddress()).isEqualTo("서울시 강남구");
+        assertThat(found.getUser().getNickname()).isEqualTo("nick");
+        assertThat(found.getStore().getName()).isEqualTo("치킨집");
+        assertThat(found.getOrderMenuList())
+            .extracting(om -> om.getMenu().getName())
+            .containsExactlyInAnyOrder("후라이드", "양념치킨");
     }
 }

--- a/src/test/java/com/sparta/tdd/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/order/service/OrderServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
 import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
 import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.menu.repository.MenuRepository;
@@ -19,6 +20,7 @@ import com.sparta.tdd.domain.orderMenu.mapper.OrderMenuMapper;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
@@ -77,6 +79,12 @@ class OrderServiceTest {
         ReflectionTestUtils.setField(user, "id", 1L);
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        UserDetailsImpl userDetails = new UserDetailsImpl(
+            1L,                           // userId
+            "testUser",                   // username
+            UserAuthority.CUSTOMER             // enum UserAuthority
+        );
 
         System.out.println("userId: " + user.getId());
 
@@ -148,8 +156,10 @@ class OrderServiceTest {
             List.of(friedReq, seasonedReq)
         );
 
+
+
         // when
-        OrderResponseDto response = orderService.createOrder(user.getId(), reqDto);
+        OrderResponseDto response = orderService.createOrder(userDetails, reqDto);
 
         System.out.println("===== OrderResponseDto =====");
         System.out.println("id = " + response.id());


### PR DESCRIPTION
## OrderController 

### .getOrder
- 검색 옵션(dto)과 페이징 객체를 받아오게 되었습니다

### 공통
- 각 요청 호출 및 종료시 log 가 출력되도록 하였습니다
- Service 에 넘겨주는 인자가 
userId -> userDetails 로 변경되었습니다
  (유저 권한도 서비스로 넘겨주기 위함)

## OrderResponseDto
- 응답필드 orderStatus 를 추가하였습니다

## OrderSearchOptionDto
- 컨트롤러에서 받아오는 검색조건 컬럼들을 한번에 받아올 수 있는 Dto 입니다
  (Param 으로 받아오니 Controller 가 너무 두꺼워졌고 검색조건이 많아짐에 따라 dto 로 관리하는 것이 좋다고 생각되었습니다)

## Order
- orderStatus, orderMenu 필드의 초기화를 삭제하였습니다
  (Builder 로만 생성되기 때문에 Builder 내부로 이관)

- address 필드의 nullable false 추가

## OrderRepository
- OrderRepository JPQL 을 사용한 검색쿼리를 작성하였습니다 오더전체조회시에는 쿼리가 총 3번 나가게 됩니다

(

1번 쿼리 orderId 를 검색조건에 맞게 Page 해서 가져옴

2번 쿼리 검색조건에 맞는 total size 를 찾는 쿼리

3번 각 orderId 에 맞는 연관 테이블을 조회하는 쿼리

)

---

## Test

### OrderRepositoryTest
- 단건조회에 관한 테스트코드를 작성하였습니다

### OrderServiceTest
- OrderService 가 받는 인자가 변함에 따라 동기화하였습니다

---

## 이후 예정사항

1. 튜터님 피드백에 따른 Service 계층 리팩토링
2. 권한에 따른 동작 분화 추가
3. 단위 테스트코드 작성 및 이전 테스트코드 리팩토링

예정순서는 팀내 회의에 따라 변경될 수 있습니다 감사합니다

