### PR TITLE
feat(ai): 음식 소개 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation("io.github.openfeign.querydsl:querydsl-jpa:7.0")
     annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:7.0:jpa")
 
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // Google GenAi
     implementation 'com.google.genai:google-genai:1.18.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     implementation("io.github.openfeign.querydsl:querydsl-core:7.0")
     implementation("io.github.openfeign.querydsl:querydsl-jpa:7.0")
     annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:7.0:jpa")
+
+    // Google GenAi
+    implementation 'com.google.genai:google-genai:1.18.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,6 @@ dependencies {
     implementation("io.github.openfeign.querydsl:querydsl-jpa:7.0")
     annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:7.0:jpa")
 
-    // webflux
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
     // Google GenAi
     implementation 'com.google.genai:google-genai:1.18.0'
 }

--- a/src/main/java/com/sparta/tdd/domain/ai/config/GenerateContentWithConfigs.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/config/GenerateContentWithConfigs.java
@@ -1,0 +1,47 @@
+package com.sparta.tdd.domain.ai.config;
+
+import autovalue.shaded.com.google.common.collect.ImmutableList;
+import com.google.genai.Client;
+import com.google.genai.types.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GenerateContentWithConfigs {
+
+    @Value("${GOOGLE_API_KEY}")
+    private String apiKey;
+    @Bean
+    public Client client() {
+        return Client.builder().apiKey(apiKey).build();
+    }
+    @Bean
+    public GenerateContentConfig generateContentConfig() {
+        ImmutableList<SafetySetting> safetySettings =
+                ImmutableList.of(
+                        SafetySetting.builder()
+                                .category(HarmCategory.Known.HARM_CATEGORY_HATE_SPEECH)
+                                .threshold(HarmBlockThreshold.Known.BLOCK_ONLY_HIGH)
+                                .build(),
+                        SafetySetting.builder()
+                                .category(HarmCategory.Known.HARM_CATEGORY_DANGEROUS_CONTENT)
+                                .threshold(HarmBlockThreshold.Known.BLOCK_LOW_AND_ABOVE)
+                                .build());
+
+        Content systemInstruction = Content.fromParts(
+                Part.fromText(
+                        "{사용자 입력}을 바탕으로 음식점에서 손님의 이목을 끌만한 20자 이하의 짧은 소개글을 만들어주세요. 문장은 한 줄로 작성합니다."));
+
+        Tool googleSearchTool = Tool.builder().googleSearch(GoogleSearch.builder()).build();
+
+        return GenerateContentConfig.builder()
+                        .thinkingConfig(ThinkingConfig.builder().thinkingBudget(0))
+                        .candidateCount(1)
+                        .maxOutputTokens(1024)
+                        .safetySettings(safetySettings)
+                        .systemInstruction(systemInstruction)
+                        .tools(googleSearchTool)
+                        .build();
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/ai/controller/AiController.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/controller/AiController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URI;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/ai")
@@ -24,7 +26,8 @@ public class AiController {
     @Operation(summary = "AI 글 생성")
     public ResponseEntity<AiResponseDto> createComment(@RequestBody AiRequestDto requestDto,
                                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        AiResponseDto createdComment = aiService.createComment(requestDto, userDetails);
+        AiResponseDto createdComment = aiService.createComment(requestDto, userDetails.getUserId());
+
         return ResponseEntity.ok(createdComment);
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/ai/controller/AiController.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/controller/AiController.java
@@ -1,0 +1,30 @@
+package com.sparta.tdd.domain.ai.controller;
+
+import com.sparta.tdd.domain.ai.dto.AiRequestDto;
+import com.sparta.tdd.domain.ai.dto.AiResponseDto;
+import com.sparta.tdd.domain.ai.service.AiService;
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/ai")
+public class AiController {
+
+    private final AiService aiService;
+
+    @PostMapping("/req")
+    @Operation(summary = "AI 글 생성")
+    public ResponseEntity<AiResponseDto> createComment(@RequestBody AiRequestDto requestDto,
+                                                       @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        AiResponseDto createdComment = aiService.createComment(requestDto, userDetails);
+        return ResponseEntity.ok(createdComment);
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/ai/dto/AiRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/dto/AiRequestDto.java
@@ -1,0 +1,6 @@
+package com.sparta.tdd.domain.ai.dto;
+
+public record AiRequestDto(
+        String comment
+) {
+}

--- a/src/main/java/com/sparta/tdd/domain/ai/dto/AiResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/dto/AiResponseDto.java
@@ -1,9 +1,22 @@
 package com.sparta.tdd.domain.ai.dto;
 
+import com.sparta.tdd.domain.ai.entity.Ai;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 public record AiResponseDto(
-        String comment
+        UUID id,
+        String inputText,
+        String outputText,
+        LocalDateTime createdAt
 ) {
-    public static AiResponseDto from(String text) {
-        return new AiResponseDto(text);
+    public static AiResponseDto from(Ai ai) {
+        return new AiResponseDto(
+                ai.getId(),
+                ai.getInputText(),
+                ai.getOutputText(),
+                ai.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/ai/dto/AiResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/dto/AiResponseDto.java
@@ -1,0 +1,9 @@
+package com.sparta.tdd.domain.ai.dto;
+
+public record AiResponseDto(
+        String comment
+) {
+    public static AiResponseDto from(String text) {
+        return new AiResponseDto(text);
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/ai/entity/Ai.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/entity/Ai.java
@@ -46,7 +46,7 @@ public class Ai extends BaseEntity {
         this.user = user;
     }
 
-    public static Ai toEntity(String inputText, String outputText, User user) {
+    public static Ai of(String inputText, String outputText, User user) {
         return Ai.builder()
                 .inputText(inputText)
                 .outputText(outputText)

--- a/src/main/java/com/sparta/tdd/domain/ai/entity/Ai.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/entity/Ai.java
@@ -45,4 +45,12 @@ public class Ai extends BaseEntity {
         this.outputText = outputText;
         this.user = user;
     }
+
+    public static Ai toEntity(String inputText, String outputText, User user) {
+        return Ai.builder()
+                .inputText(inputText)
+                .outputText(outputText)
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/tdd/domain/ai/entity/Ai.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/entity/Ai.java
@@ -21,9 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "p_ai")
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Ai extends BaseEntity {
 
     @Id
@@ -40,4 +38,11 @@ public class Ai extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @Builder
+    public Ai(String inputText, String outputText, User user) {
+        this.inputText = inputText;
+        this.outputText = outputText;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
@@ -32,7 +32,7 @@ public class AiService {
                 new IllegalArgumentException("존재하지 않는 회원입니다.")
         );
 
-        Ai ai = Ai.toEntity(requestDto.comment(), response, user);
+        Ai ai = Ai.of(requestDto.comment(), response, user);
 
         aiRepository.save(ai);
         log.info(getLog(ai));

--- a/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
@@ -32,11 +32,7 @@ public class AiService {
                 new IllegalArgumentException("존재하지 않는 회원입니다.")
         );
 
-        Ai ai = Ai.builder()
-                .inputText(requestDto.comment())
-                .outputText(response)
-                .user(user)
-                .build();
+        Ai ai = Ai.toEntity(requestDto.comment(), response, user);
 
         aiRepository.save(ai);
         log.info(getLog(ai));

--- a/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
@@ -1,0 +1,44 @@
+package com.sparta.tdd.domain.ai.service;
+
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentResponse;
+import com.sparta.tdd.domain.ai.dto.AiRequestDto;
+import com.sparta.tdd.domain.ai.dto.AiResponseDto;
+import com.sparta.tdd.domain.ai.entity.Ai;
+import com.sparta.tdd.domain.ai.repository.AiRepository;
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import com.sparta.tdd.domain.user.entity.User;
+import com.sparta.tdd.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiService {
+
+    private final AiRepository aiRepository;
+    private final UserRepository userRepository;
+
+    @Value("${GOOGLE_API_KEY}")
+    private String key;
+    public AiResponseDto createComment(AiRequestDto requestDto, UserDetailsImpl userDetails) {
+        Client client = Client.builder().apiKey(key).build();
+
+        GenerateContentResponse contentResponse =
+                client.models.generateContent("gemini-2.5-flash", "다음 요청에 대한 소개글을 20자를 넘지않게 작성해줘. " + requestDto.comment(), null);
+
+        User user = userRepository.findById(userDetails.getUserId()).orElseThrow(() ->
+                new IllegalArgumentException("존재하지 않는 회원입니다.")
+        );
+
+        Ai ai = Ai.builder()
+                .inputText(requestDto.comment())
+                .outputText(contentResponse.text())
+                .user(user)
+                .build();
+
+        aiRepository.save(ai);
+        return AiResponseDto.from(ai.getOutputText());
+    }
+}

--- a/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/service/AiService.java
@@ -26,12 +26,11 @@ public class AiService {
     private final GenerateContentConfig config;
 
     public AiResponseDto createComment(AiRequestDto requestDto, Long userId) {
-        String response = generateText(requestDto.comment());
-
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new IllegalArgumentException("존재하지 않는 회원입니다.")
         );
 
+        String response = generateText(requestDto.comment());
         Ai ai = Ai.of(requestDto.comment(), response, user);
 
         aiRepository.save(ai);


### PR DESCRIPTION
처음에는 WebClient로 직접 요청을 보내 구현하려고 했지만 SDK를 활용하는 방식이 더 간단하고 효율적이라고 판단하여 적용했습니다.
API 키는 노션의 환경변수 페이지에 올려놓았습니다.
### PR 내용
----
[chore(ai): google genai 의존성 추가](https://github.com/Sparta-21/TDD/commit/8d40a97032cee1d19e1553fd58458b196dbf596b)
- google genai sdk를 사용하기 위해서 의존성을 추가했습니다. [genai](https://github.com/googleapis/java-genai?tab=readme-ov-file)

[feat(ai): 음식 소개 생성 기능 구현](https://github.com/Sparta-21/TDD/commit/33c2a5880071af52a6fca605efd0e805d422a6e7)
- 생성 기능에 대한 비즈니스 로직을 작성했습니다.

[feat(ai): GenerateContentWithConfigs 추가](https://github.com/Sparta-21/TDD/commit/43b440d6fb70c1478227015da3b6b66a5e0d8170)
- GenAi 모델 설정을 Config 클래스로 분리하여 빈으로 등록했습니다.
- AI 코멘트 생성 시 입력/출력에 대한 로깅을 추가했습니다.
- 현재는 Postman을 통해 응답 문장 생성까지 확인하였으며, 추후 서비스 계층 단위 테스트를 추가할 예정입니다.