### PR TITLE
feat(menu): MenuService 모든 메서드 테스트코드 작성 및 추가 수정

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
@@ -4,6 +4,7 @@ import com.sparta.tdd.domain.auth.UserDetailsImpl;
 import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
 import com.sparta.tdd.domain.menu.dto.MenuResponseDto;
 import com.sparta.tdd.domain.menu.service.MenuService;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,16 +30,20 @@ public class MenuController {
     private final MenuService menuService;
 
     @GetMapping("/{storeId}/menu")
-    public ResponseEntity<List<MenuResponseDto>> getMenus(@PathVariable UUID storeId) {
+    public ResponseEntity<List<MenuResponseDto>> getMenus(@PathVariable UUID storeId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserAuthority authority = userDetails.getUserAuthority();
         return ResponseEntity.status(HttpStatus.OK)
-            .body(menuService.getMenus(storeId));
+            .body(menuService.getMenus(storeId, authority));
     }
 
     @GetMapping("/{storeId}/menu/{menuId}")
     public ResponseEntity<MenuResponseDto> getMenu(@PathVariable UUID storeId,
-        @PathVariable UUID menuId) {
+        @PathVariable UUID menuId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        UserAuthority authority = userDetails.getUserAuthority();
         return ResponseEntity.status(HttpStatus.OK)
-            .body(menuService.getMenu(storeId, menuId));
+            .body(menuService.getMenu(storeId, menuId, authority));
     }
 
     @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")

--- a/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,45 +29,44 @@ public class MenuController {
     private final MenuService menuService;
 
     @GetMapping("/{storeId}/menu")
-    public ResponseEntity<List<MenuResponseDto>> getMenus(@PathVariable UUID storeId,
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<List<MenuResponseDto>> getMenus(@PathVariable UUID storeId) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(menuService.getMenus(storeId));
     }
 
     @GetMapping("/{storeId}/menu/{menuId}")
     public ResponseEntity<MenuResponseDto> getMenu(@PathVariable UUID storeId,
-        @PathVariable UUID menuId,
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        @PathVariable UUID menuId) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(menuService.getMenu(storeId, menuId));
     }
 
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @PostMapping("/{storeId}/menu")
     public ResponseEntity<MenuResponseDto> createMenu(@PathVariable UUID storeId,
-        @RequestBody MenuRequestDto menuRequestDto,
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        @RequestBody MenuRequestDto menuRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(menuService.createMenu(storeId, menuRequestDto));
     }
 
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @PatchMapping("/{storeId}/menu/{menuId}")
     public ResponseEntity<Void> updateMenu(@PathVariable UUID storeId, @PathVariable UUID menuId,
-        @RequestBody MenuRequestDto menuRequestDto,
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        @RequestBody MenuRequestDto menuRequestDto) {
         menuService.updateMenu(storeId, menuId, menuRequestDto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @PatchMapping("/{storeId}/menu/{menuId}/status")
     public ResponseEntity<Void> updateMenuStatus(@PathVariable UUID storeId,
         @PathVariable UUID menuId,
-        @RequestParam Boolean status,
-        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        @RequestParam Boolean status) {
         menuService.updateMenuStatus(storeId, menuId, status);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
     @DeleteMapping("/{storeId}/menu/{menuId}")
     public ResponseEntity<Void> deleteMenu(@PathVariable UUID storeId, @PathVariable UUID menuId,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -54,6 +55,15 @@ public class MenuController {
         @RequestBody MenuRequestDto menuRequestDto,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
         menuService.updateMenu(storeId, menuId, menuRequestDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PatchMapping("/{storeId}/menu/{menuId}/status")
+    public ResponseEntity<Void> updateMenuStatus(@PathVariable UUID storeId,
+        @PathVariable UUID menuId,
+        @RequestParam Boolean status,
+        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        menuService.updateMenuStatus(storeId, menuId, status);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/controller/MenuController.java
@@ -46,7 +46,7 @@ public class MenuController {
             .body(menuService.getMenu(storeId, menuId, authority));
     }
 
-    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasAnyRole('ROLE_OWNER', 'ROLE_MASTER')")
     @PostMapping("/{storeId}/menu")
     public ResponseEntity<MenuResponseDto> createMenu(@PathVariable UUID storeId,
         @RequestBody MenuRequestDto menuRequestDto) {
@@ -54,7 +54,7 @@ public class MenuController {
             .body(menuService.createMenu(storeId, menuRequestDto));
     }
 
-    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasAnyRole('ROLE_OWNER', 'ROLE_MASTER')")
     @PatchMapping("/{storeId}/menu/{menuId}")
     public ResponseEntity<Void> updateMenu(@PathVariable UUID storeId, @PathVariable UUID menuId,
         @RequestBody MenuRequestDto menuRequestDto) {
@@ -62,7 +62,7 @@ public class MenuController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasAnyRole('ROLE_OWNER', 'ROLE_MASTER')")
     @PatchMapping("/{storeId}/menu/{menuId}/status")
     public ResponseEntity<Void> updateMenuStatus(@PathVariable UUID storeId,
         @PathVariable UUID menuId,
@@ -71,7 +71,7 @@ public class MenuController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @PreAuthorize("hasRole('ROLE_OWNER') or hasRole('ROLE_MASTER')")
+    @PreAuthorize("hasAnyRole('ROLE_OWNER', 'ROLE_MASTER')")
     @DeleteMapping("/{storeId}/menu/{menuId}")
     public ResponseEntity<Void> deleteMenu(@PathVariable UUID storeId, @PathVariable UUID menuId,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/sparta/tdd/domain/menu/dto/MenuRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/dto/MenuRequestDto.java
@@ -1,5 +1,7 @@
 package com.sparta.tdd.domain.menu.dto;
 
+import com.sparta.tdd.domain.menu.entity.Menu;
+import com.sparta.tdd.domain.store.entity.Store;
 import lombok.Builder;
 
 @Builder
@@ -10,4 +12,9 @@ public record MenuRequestDto(
     String imageUrl
 ) {
 
+    public Menu toEntity(Store store) {
+        return Menu.builder()
+            .dto(this)
+            .store(store).build();
+    }
 }

--- a/src/main/java/com/sparta/tdd/domain/menu/dto/MenuRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/dto/MenuRequestDto.java
@@ -1,5 +1,8 @@
 package com.sparta.tdd.domain.menu.dto;
 
+import lombok.Builder;
+
+@Builder
 public record MenuRequestDto(
     String name,
     String description,

--- a/src/main/java/com/sparta/tdd/domain/menu/dto/MenuResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/dto/MenuResponseDto.java
@@ -2,7 +2,9 @@ package com.sparta.tdd.domain.menu.dto;
 
 import com.sparta.tdd.domain.menu.entity.Menu;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record MenuResponseDto(
     UUID menuId,
     String name,
@@ -13,13 +15,12 @@ public record MenuResponseDto(
 ) {
 
     public static MenuResponseDto from(Menu menu) {
-        return new MenuResponseDto(
-            menu.getId(),
-            menu.getName(),
-            menu.getDescription(),
-            menu.getPrice(),
-            menu.getImageUrl(),
-            menu.getIsHidden()
-        );
+        return MenuResponseDto.builder()
+            .menuId(menu.getId())
+            .name(menu.getName())
+            .description(menu.getDescription())
+            .price(menu.getPrice())
+            .imageUrl(menu.getImageUrl())
+            .isHidden(menu.getIsHidden()).build();
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/entity/Menu.java
@@ -43,6 +43,9 @@ public class Menu extends BaseEntity {
     @Column(name = "is_hidden", nullable = false)
     private Boolean isHidden = false;
 
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
@@ -63,10 +66,14 @@ public class Menu extends BaseEntity {
         this.imageUrl = dto.imageUrl();
     }
 
+    public void updateStatus(Boolean status) {
+        this.isHidden = status;
+    }
+
     @Override
     public void delete(Long deleteBy) {
         super.delete(deleteBy);
         this.isHidden = true;
+        this.isDeleted = true;
     }
-
 }

--- a/src/main/java/com/sparta/tdd/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/entity/Menu.java
@@ -59,6 +59,10 @@ public class Menu extends BaseEntity {
         this.store = store;
     }
 
+    public boolean isHidden() {
+        return isHidden;
+    }
+
     public void update(MenuRequestDto dto) {
         this.name = dto.name();
         this.description = dto.description();

--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
@@ -11,4 +11,6 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
     List<Menu> findAllByStoreId(UUID storeId);
 
     Optional<Menu> findByStoreIdAndId(UUID storeId, UUID menuId);
+
+    List<Menu> findAllByStoreIdAndIsHiddenFalse(UUID storeId);
 }

--- a/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
@@ -43,9 +43,7 @@ public class MenuService {
 
     @Transactional
     public MenuResponseDto createMenu(UUID storeId, MenuRequestDto menuRequestDto) {
-        Menu menu = Menu.builder()
-            .dto(menuRequestDto)
-            .store(findStore(storeId)).build();
+        Menu menu = menuRequestDto.toEntity(findStore(storeId));
         menuRepository.save(menu);
 
         return MenuResponseDto.from(menu);

--- a/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
@@ -51,6 +51,12 @@ public class MenuService {
     }
 
     @Transactional
+    public void updateMenuStatus(UUID storeId, UUID menuId, Boolean status) {
+        Menu menu = findMenu(storeId, menuId);
+        menu.updateStatus(status);
+    }
+
+    @Transactional
     public void deleteMenu(UUID storeId, UUID menuId, Long userId) {
         Menu menu = findMenu(storeId, menuId);
         menu.delete(userId);

--- a/src/main/java/com/sparta/tdd/domain/user/enums/UserAuthority.java
+++ b/src/main/java/com/sparta/tdd/domain/user/enums/UserAuthority.java
@@ -12,4 +12,8 @@ public enum UserAuthority {
     MASTER("최종 관리자");
 
     private final String description;
+
+    public boolean isCustomerOrManager() {
+        return this == CUSTOMER || this == MANAGER;
+    }
 }

--- a/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
@@ -100,15 +100,11 @@ public class MenuServiceTest {
             .imageUrl("this is image url").build();
 
         // 정상 메뉴
-        menu1 = Menu.builder()
-            .dto(dto1)
-            .store(store).build();
+        menu1 = dto1.toEntity(store);
         setMenuId(menu1, menu1Id);
 
         // 숨겨진 메뉴
-        menu2 = Menu.builder()
-            .dto(dto2)
-            .store(store).build();
+        menu2 = dto2.toEntity(store);
         setMenuId(menu2, menu2Id);
         setMenuIsHidden(menu2, true);
     }

--- a/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
@@ -1,0 +1,126 @@
+package com.sparta.tdd.domain.menu.service;
+
+import static jdk.jfr.internal.jfc.model.Constraint.any;
+
+import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
+import com.sparta.tdd.domain.menu.entity.Menu;
+import com.sparta.tdd.domain.menu.repository.MenuRepository;
+import com.sparta.tdd.domain.store.entity.Store;
+import com.sparta.tdd.domain.store.enums.StoreCategory;
+import com.sparta.tdd.domain.user.entity.User;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
+import java.lang.reflect.Field;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class MenuServiceTest {
+
+    @InjectMocks
+    MenuService menuService;
+
+    @Mock
+    MenuRepository menuRepository;
+
+    User customer;
+    User owner;
+    Store store;
+    MenuRequestDto dto1;
+    MenuRequestDto dto2;
+    Menu menu1;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        UUID storeId = UUID.randomUUID();
+        UUID menu1Id = UUID.randomUUID();
+
+        customer = User.builder()
+            .username("customer")
+            .password("password1")
+            .nickname("test1")
+            .authority(UserAuthority.CUSTOMER).build();
+        setUserId(customer, 1L);
+
+        owner = User.builder()
+            .username("owner")
+            .password("password2")
+            .nickname("test2")
+            .authority(UserAuthority.OWNER).build();
+        setUserId(owner, 2L);
+
+        store = Store.builder()
+            .name("store")
+            .category(StoreCategory.KOREAN)
+            .description("this is store description")
+            .imageUrl("this is image url")
+            .user(owner).build();
+        setStoreId(store, storeId);
+
+        dto1 = MenuRequestDto.builder()
+            .name("menu1")
+            .description("this is menu1")
+            .price(5000)
+            .imageUrl("this is image url").build();
+
+        dto2 = MenuRequestDto.builder()
+            .name("menu2")
+            .description("this is menu2")
+            .price(10000)
+            .imageUrl("this is image url").build();
+
+        dto3 = MenuRequestDto.builder()
+            .name("menu3")
+            .description("this is menu3")
+            .price(15000)
+            .imageUrl("this is image url").build();
+
+        menu1 = Menu.builder()
+            .dto(dto1)
+            .store(store).build();
+        setMenuId(menu1, menu1Id);
+    }
+
+    private void setUserId(User user, Long id) throws Exception {
+        Field field = User.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(user, id);
+    }
+
+    private void setStoreId(Store store, UUID id) throws Exception {
+        Field field = Store.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(store, id);
+    }
+
+    private void setMenuId(Menu menu, UUID id) throws Exception {
+        Field field = Menu.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(menu, id);
+    }
+
+    @Test
+    void createMenuSuccessTest() {
+        // when
+        when(menuRepository.save(any(Menu.class))).thenReturn();
+        Menu testMenu = menuService.createMenu(store.getId(), dto);
+
+        // then
+        assertEquals(dto.name(), createdMenu.getName());
+        assertEquals(dto.price(), createdMenu.getPrice());
+        assertEquals(dto.imageUrl(), createdMenu.getImageUrl());
+        assertEquals(dto.description(), createdMenu.getDescription());
+    }
+
+    @Test
+    void getMenusTest() {
+        // given
+
+        // when
+
+        // then
+        // verify(menuRepository, times(1)).find(any(Menu.class));
+
+    }
+}

--- a/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
@@ -1,21 +1,38 @@
 package com.sparta.tdd.domain.menu.service;
 
-import static jdk.jfr.internal.jfc.model.Constraint.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
+import com.sparta.tdd.domain.menu.dto.MenuResponseDto;
 import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.menu.repository.MenuRepository;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
+import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class MenuServiceTest {
 
     @InjectMocks
@@ -24,17 +41,23 @@ public class MenuServiceTest {
     @Mock
     MenuRepository menuRepository;
 
+    @Mock
+    StoreRepository storeRepository;
+
     User customer;
     User owner;
     Store store;
     MenuRequestDto dto1;
     MenuRequestDto dto2;
+    MenuRequestDto dto3;
     Menu menu1;
+    Menu menu2;
 
     @BeforeEach
     void setUp() throws Exception {
         UUID storeId = UUID.randomUUID();
         UUID menu1Id = UUID.randomUUID();
+        UUID menu2Id = UUID.randomUUID();
 
         customer = User.builder()
             .username("customer")
@@ -76,12 +99,172 @@ public class MenuServiceTest {
             .price(15000)
             .imageUrl("this is image url").build();
 
+        // 정상 메뉴
         menu1 = Menu.builder()
             .dto(dto1)
             .store(store).build();
         setMenuId(menu1, menu1Id);
+
+        // 숨겨진 메뉴
+        menu2 = Menu.builder()
+            .dto(dto2)
+            .store(store).build();
+        setMenuId(menu2, menu2Id);
+        setMenuIsHidden(menu2, true);
     }
 
+    @Nested
+    @DisplayName("권한별 메뉴 목록 조회")
+    class GetMenus {
+
+        @Test
+        @DisplayName("Customer 메뉴 목록 조회 테스트")
+        void getMenusCustomerTest() {
+            // given
+            when(menuRepository.findAllByStoreIdAndIsHiddenFalse(store.getId()))
+                .thenReturn(List.of(menu1));
+
+            // when
+            List<MenuResponseDto> testMenus = menuService.getMenus(store.getId(),
+                customer.getAuthority());
+
+            // then
+            assertNotNull(testMenus);
+            verify(menuRepository, times(1)).findAllByStoreIdAndIsHiddenFalse(store.getId());
+            verify(menuRepository, never()).findAllByStoreId(any());
+            assertTrue(testMenus.stream().anyMatch(m -> m.menuId().equals(menu1.getId())));
+            assertTrue(testMenus.stream().noneMatch(m -> m.menuId().equals(menu2.getId())));
+        }
+
+        @Test
+        @DisplayName("OWNER 메뉴 목록 조회 테스트")
+        void getMenusOwnerTest() {
+            // given
+            when(menuRepository.findAllByStoreId(store.getId()))
+                .thenReturn(List.of(menu1, menu2));
+
+            // when
+            List<MenuResponseDto> testMenus = menuService.getMenus(store.getId(),
+                owner.getAuthority());
+
+            // then
+            assertNotNull(testMenus);
+            verify(menuRepository, times(1)).findAllByStoreId(store.getId());
+            verify(menuRepository, never()).findAllByStoreIdAndIsHiddenFalse(any());
+            assertTrue(testMenus.stream().anyMatch(m -> m.menuId().equals(menu1.getId())));
+            assertTrue(testMenus.stream().anyMatch(m -> m.menuId().equals(menu2.getId())));
+        }
+    }
+
+    @Nested
+    @DisplayName("권한별 메뉴 상세 조회")
+    class GetMenu {
+
+        @Test
+        @DisplayName("Customer 메뉴 상세 테스트")
+        void getMenusCustomerTest() {
+            //given
+            when(menuRepository.findByStoreIdAndId(store.getId(), menu2.getId()))
+                .thenReturn(Optional.of(menu2));
+
+            // when & then
+            assertThrows(IllegalArgumentException.class,
+                () -> menuService.getMenu(store.getId(), menu2.getId(),
+                    customer.getAuthority()));
+            verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu2.getId());
+        }
+
+        @Test
+        @DisplayName("OWNER 메뉴 상세 테스트")
+        void getMenusOwnerTest() {
+            //given
+            when(menuRepository.findByStoreIdAndId(store.getId(), menu2.getId()))
+                .thenReturn(Optional.of(menu2));
+
+            // when
+            MenuResponseDto testMenu = menuService.getMenu(store.getId(), menu2.getId(),
+                owner.getAuthority());
+
+            // then
+            assertNotNull(testMenu);
+            assertEquals(menu2.getId(), testMenu.menuId());
+            verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu2.getId());
+        }
+
+    }
+
+    @Test
+    @DisplayName("메뉴 등록 테스트")
+    void createMenuSuccessTest() {
+        // given
+        when(storeRepository.findById(store.getId()))
+            .thenReturn(Optional.of(store));
+
+        // when
+        MenuResponseDto testMenu = menuService.createMenu(store.getId(), dto3);
+
+        // then
+        assertNotNull(testMenu);
+        assertEquals(dto3.name(), testMenu.name());
+        assertEquals(dto3.description(), testMenu.description());
+        assertEquals(dto3.price(), testMenu.price());
+        assertEquals(dto3.imageUrl(), testMenu.imageUrl());
+        assertEquals(Boolean.FALSE, testMenu.isHidden());
+        verify(menuRepository, times(1)).save(any(Menu.class));
+        verify(storeRepository, times(1)).findById(store.getId());
+    }
+
+    @Test
+    @DisplayName("메뉴 수정 테스트")
+    void updateMenuSuccessTest() {
+        // given
+        when(menuRepository.findByStoreIdAndId(store.getId(), menu1.getId()))
+            .thenReturn(Optional.of(menu1));
+
+        // when
+        menuService.updateMenu(store.getId(), menu1.getId(), dto3);
+
+        // then
+        verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu1.getId());
+        assertEquals(dto3.name(), menu1.getName());
+        assertEquals(dto3.description(), menu1.getDescription());
+        assertEquals(dto3.price(), menu1.getPrice());
+        assertEquals(dto3.imageUrl(), menu1.getImageUrl());
+        assertEquals(Boolean.FALSE, menu1.isHidden());
+    }
+
+    @Test
+    @DisplayName("메뉴 상태 수정 테스트")
+    void updateMenuStatusSuccessTest() {
+        // given
+        when(menuRepository.findByStoreIdAndId(store.getId(), menu1.getId()))
+            .thenReturn(Optional.of(menu1));
+
+        // when
+        menuService.updateMenuStatus(store.getId(), menu1.getId(), Boolean.TRUE);
+
+        // then
+        verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu1.getId());
+        assertTrue(menu1.isHidden());
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제 테스트(soft delete)")
+    void deleteMenuSuccessTest() {
+        // given
+        when(menuRepository.findByStoreIdAndId(store.getId(), menu1.getId()))
+            .thenReturn(Optional.of(menu1));
+
+        // when
+        menuService.deleteMenu(store.getId(), menu1.getId(), owner.getId());
+
+        // then
+        verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu1.getId());
+        assertNotNull(menu1.getDeletedAt());
+        assertEquals(owner.getId(), menu1.getDeletedBy());
+    }
+
+    // Reflection
     private void setUserId(User user, Long id) throws Exception {
         Field field = User.class.getDeclaredField("id");
         field.setAccessible(true);
@@ -100,27 +283,9 @@ public class MenuServiceTest {
         field.set(menu, id);
     }
 
-    @Test
-    void createMenuSuccessTest() {
-        // when
-        when(menuRepository.save(any(Menu.class))).thenReturn();
-        Menu testMenu = menuService.createMenu(store.getId(), dto);
-
-        // then
-        assertEquals(dto.name(), createdMenu.getName());
-        assertEquals(dto.price(), createdMenu.getPrice());
-        assertEquals(dto.imageUrl(), createdMenu.getImageUrl());
-        assertEquals(dto.description(), createdMenu.getDescription());
-    }
-
-    @Test
-    void getMenusTest() {
-        // given
-
-        // when
-
-        // then
-        // verify(menuRepository, times(1)).find(any(Menu.class));
-
+    private void setMenuIsHidden(Menu menu, Boolean isHidden) throws Exception {
+        Field field = Menu.class.getDeclaredField("isHidden");
+        field.setAccessible(true);
+        field.set(menu, isHidden);
     }
 }


### PR DESCRIPTION
[feat(menu): updateMenuStatus api 구현(포스트맨 테스트 완료)](https://github.com/Sparta-21/TDD/commit/2cf552c202438e1aa8853673110e5ce8b85b67f8)
- updateMenuStatus API 구현

[feat(menu): isHidden 관련 서비스 권한처리로직 구현, userAuthority 에 메서드 추가](https://github.com/Sparta-21/TDD/commit/9226f5107168efe51338bfdb1321831307570b93)
- isHidden 속성 추가에 따른 getMenus, getMenu 권한 처리 로직 추가

[test(menu): MenuService 테스트코드 작성](https://github.com/Sparta-21/TDD/commit/6c5ab45dea992c3dbab90e2559f4a5cc28ebb46b)
- menu 모든 메서드에 대한 테스트코드 작성
-  createMenu, updateMenu, updateStatusMenu, deleteMenu  
   > 권한 차단이 컨트롤러에 되어있어서 해당 메서드는 컨트롤러-서비스 통합 테스트에서 실패케이스 작성 예정

[refactor(menu): toEntity 추가 및 변경](https://github.com/Sparta-21/TDD/commit/b074a07deb107fca3b5cdd225148611e8791985b)
- dto toEntity 방식으로 추가 및 수정
- 사소하지만, 추가로 이 부분에 대하여 저는 dto를 통째로 빌더에 넣는데 다른분들과는 살짝 방식이 다른것 같아서 어떻게 하는것이 더 나을지 의견 부탁드립니다!