### PR TITLE
test: TestContainer을 활용한 테스트 템플릿 작성 및 인증 모킹 어노테이션 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:postgresql'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'

--- a/src/main/java/com/sparta/tdd/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/tdd/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -61,6 +62,13 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("handleIllegalArgumentException : {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    protected ResponseEntity<String> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+        log.warn("handleAuthorizationDeniedException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(e.getMessage());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,3 +66,20 @@ logging:
     root: INFO
     org.hibernate.SQL: OFF
     org.hibernate.type.descriptor.sql.BasicBinder: OFF
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+
+jwt:
+  access:
+    secret: testAccessSecrettestAccessSecret
+    expiration: 2000
+  refresh:
+    secret: testRefreshSecrettestRefreshSecret
+    expiration: 2000

--- a/src/test/java/com/sparta/tdd/common/config/TestContainerConfig.java
+++ b/src/test/java/com/sparta/tdd/common/config/TestContainerConfig.java
@@ -1,0 +1,17 @@
+package com.sparta.tdd.common.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfig {
+
+    @Bean
+    @ServiceConnection
+    public PostgreSQLContainer<?> postgreSQLContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:18"));
+    }
+}

--- a/src/test/java/com/sparta/tdd/common/config/TestSecurityConfig.java
+++ b/src/test/java/com/sparta/tdd/common/config/TestSecurityConfig.java
@@ -1,0 +1,39 @@
+package com.sparta.tdd.common.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableMethodSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .anyRequest().authenticated())
+            .exceptionHandling(exception -> exception
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    response.setContentType("application/json;charset=UTF-8");
+                    response.getWriter().write("{\"error\":\"접근 권한이 없습니다\"}");
+                }));
+
+        return http.build();
+    }
+
+}

--- a/src/test/java/com/sparta/tdd/common/helper/CleanUp.java
+++ b/src/test/java/com/sparta/tdd/common/helper/CleanUp.java
@@ -1,0 +1,45 @@
+package com.sparta.tdd.common.helper;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Table;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class CleanUp {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final EntityManager entityManager;
+
+    public CleanUp(JdbcTemplate jdbcTemplate, EntityManager entityManager) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.entityManager = entityManager;
+    }
+
+    @Transactional
+    public void all() {
+        Set<String> tables = entityManager.getMetamodel().getEntities().stream()
+            .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
+            .map(entity -> {
+                Table tableAnnotation = entity.getJavaType().getAnnotation(Table.class);
+                return tableAnnotation != null ? tableAnnotation.name() : null;
+            })
+            .filter(tableName -> tableName != null && !tableName.isEmpty())
+            .collect(Collectors.toSet());
+
+        if (tables.isEmpty()) {
+            return;
+        }
+
+        try {
+            String tableList = String.join(", ", tables);
+            jdbcTemplate.execute("TRUNCATE TABLE " + tableList + " RESTART IDENTITY CASCADE");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clean up test data: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/com/sparta/tdd/common/helper/CustomWithMockUser.java
+++ b/src/test/java/com/sparta/tdd/common/helper/CustomWithMockUser.java
@@ -1,0 +1,17 @@
+package com.sparta.tdd.common.helper;
+
+import com.sparta.tdd.domain.user.enums.UserAuthority;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = CustomWithMockUserSecurityContextFactory.class)
+public @interface CustomWithMockUser {
+
+    long userId() default 1L;
+
+    String username() default "testUser";
+
+    UserAuthority authority() default UserAuthority.CUSTOMER;
+}

--- a/src/test/java/com/sparta/tdd/common/helper/CustomWithMockUserExampleTest.java
+++ b/src/test/java/com/sparta/tdd/common/helper/CustomWithMockUserExampleTest.java
@@ -1,0 +1,74 @@
+package com.sparta.tdd.common.helper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sparta.tdd.common.config.TestSecurityConfig;
+import com.sparta.tdd.domain.auth.TestAuthController;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TestAuthController.class)
+@Import(TestSecurityConfig.class)
+class CustomWithMockUserExampleTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("인증이 필요한 컨트롤러에 인증객체가 없다면 통과하지 못한다")
+    void doesNotPass_requireAuthenticationController() throws Exception {
+        mockMvc.perform(get("/v1/test/mockUser/test"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @CustomWithMockUser
+    @DisplayName("@CustomWithMockUser을 이용했을 때 정상적으로 인증이 통과된다.")
+    void withMockUser_canPassAuthentication() throws Exception {
+        mockMvc.perform(get("/v1/test/mockUser/test"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(1L))
+            .andExpect(jsonPath("$.username").value("testUser"))
+            .andExpect(jsonPath("$.authority").value("CUSTOMER"));
+    }
+
+    @Test
+    @CustomWithMockUser(userId = 5L, username = "testUser2", authority = UserAuthority.MASTER)
+    @DisplayName("@CustomWithMockUser의 옵션을 통해 인증객체의 정보를 변경할 수 있다.")
+    void withMockUser_optionCustom() throws Exception {
+        mockMvc.perform(get("/v1/test/mockUser/test"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(5L))
+            .andExpect(jsonPath("$.username").value("testUser2"))
+            .andExpect(jsonPath("$.authority").value("MASTER"));
+    }
+
+    @Test
+    @CustomWithMockUser
+    @DisplayName("Master 권한이 필요한 곳에 CUSTOMER 권한은 접근할 수 없다.")
+    void customer_cannotAccess_masterOnly() throws Exception {
+        mockMvc.perform(get("/v1/test/master-only"))
+            .andDo(print())
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @CustomWithMockUser(authority = UserAuthority.MASTER)
+    @DisplayName("Master 권한이 필요한 곳에 MASTER 권한은 접근할 수 있다.")
+    void master_canAccess_masterOnly() throws Exception {
+        mockMvc.perform(get("/v1/test/master-only"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.userId").value(1L))
+            .andExpect(jsonPath("$.username").value("testUser"))
+            .andExpect(jsonPath("$.authority").value("MASTER"));
+    }
+
+}

--- a/src/test/java/com/sparta/tdd/common/helper/CustomWithMockUserSecurityContextFactory.java
+++ b/src/test/java/com/sparta/tdd/common/helper/CustomWithMockUserSecurityContextFactory.java
@@ -1,0 +1,26 @@
+package com.sparta.tdd.common.helper;
+
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class CustomWithMockUserSecurityContextFactory implements WithSecurityContextFactory<CustomWithMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(CustomWithMockUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        UserDetailsImpl principal = new UserDetailsImpl(
+            annotation.userId(),
+            annotation.username(),
+            annotation.authority()
+        );
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
@@ -1,0 +1,33 @@
+package com.sparta.tdd.common.template;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.tdd.common.config.TestContainerConfig;
+import com.sparta.tdd.common.helper.CleanUp;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Import(TestContainerConfig.class)
+public abstract class IntegrationTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper mapper;
+
+    @Autowired
+    protected CleanUp cleanUp;
+
+    @BeforeEach
+    void setUp() {
+        cleanUp.all();
+    }
+}

--- a/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
@@ -27,7 +27,7 @@ public abstract class IntegrationTest {
     protected CleanUp cleanUp;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
         cleanUp.all();
     }
 }

--- a/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
@@ -3,6 +3,7 @@ package com.sparta.tdd.common.template;
 import com.sparta.tdd.common.config.TestContainerConfig;
 import com.sparta.tdd.common.helper.CleanUp;
 import com.sparta.tdd.global.config.AuditConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -18,4 +19,8 @@ public abstract class RepositoryTest {
     @Autowired
     protected CleanUp cleanUp;
 
+    @BeforeEach
+    void setUp() {
+        cleanUp.all();
+    }
 }

--- a/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
@@ -3,6 +3,7 @@ package com.sparta.tdd.common.template;
 import com.sparta.tdd.common.config.TestContainerConfig;
 import com.sparta.tdd.common.helper.CleanUp;
 import com.sparta.tdd.global.config.AuditConfig;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -18,6 +19,9 @@ public abstract class RepositoryTest {
 
     @Autowired
     protected CleanUp cleanUp;
+
+    @Autowired
+    protected EntityManager em;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
@@ -1,0 +1,21 @@
+package com.sparta.tdd.common.template;
+
+import com.sparta.tdd.common.config.TestContainerConfig;
+import com.sparta.tdd.common.helper.CleanUp;
+import com.sparta.tdd.global.config.AuditConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({TestContainerConfig.class, CleanUp.class, AuditConfig.class})
+public abstract class RepositoryTest {
+
+    @Autowired
+    protected CleanUp cleanUp;
+
+}

--- a/src/test/java/com/sparta/tdd/domain/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/auth/AuthIntegrationTest.java
@@ -7,42 +7,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.tdd.common.template.IntegrationTest;
 import com.sparta.tdd.domain.auth.dto.request.LoginRequestDto;
 import com.sparta.tdd.domain.auth.dto.request.SignUpRequestDto;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
-import com.sparta.tdd.domain.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
-@ActiveProfiles("local")
-class AuthIntegrationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @BeforeEach
-    void setUp() {
-        userRepository.deleteAll();
-    }
+class AuthIntegrationTest extends IntegrationTest {
 
     @Test
     @DisplayName("회원가입 후 발급받은 토큰으로 UserDetailsImpl에 올바른 데이터가 담기는지 확인")
@@ -58,7 +32,7 @@ class AuthIntegrationTest {
         // when
         MvcResult signUpResult = mockMvc.perform(post("/v1/auth/signup")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(signUpRequest)))
+                .content(mapper.writeValueAsString(signUpRequest)))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(header().exists("Authorization"))
@@ -90,7 +64,7 @@ class AuthIntegrationTest {
 
         mockMvc.perform(post("/v1/auth/signup")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(signUpRequest)))
+                .content(mapper.writeValueAsString(signUpRequest)))
             .andExpect(status().isOk());
 
         LoginRequestDto loginRequest = new LoginRequestDto(
@@ -101,7 +75,7 @@ class AuthIntegrationTest {
         // when
         MvcResult loginResult = mockMvc.perform(post("/v1/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(loginRequest)))
+                .content(mapper.writeValueAsString(loginRequest)))
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(header().exists("Authorization"))

--- a/src/test/java/com/sparta/tdd/domain/auth/TestAuthController.java
+++ b/src/test/java/com/sparta/tdd/domain/auth/TestAuthController.java
@@ -1,6 +1,7 @@
 package com.sparta.tdd.domain.auth;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,9 +24,42 @@ public class TestAuthController {
         ));
     }
 
+    @GetMapping("/mockUser/test")
+    public ResponseEntity<?> mockUserTest(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).body("인증되지 않은 사용자");
+        }
+
+        return ResponseEntity.ok(new mockUserInfo(
+            userDetails.getUserId(),
+            userDetails.getUsername(),
+            userDetails.getUserAuthority().name()
+        ));
+    }
+
+    @PreAuthorize("hasRole('MASTER')")
+    @GetMapping("/master-only")
+    public ResponseEntity<?> masterOnlyAccessTest(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(new mockUserInfo(
+            userDetails.getUserId(),
+            userDetails.getUsername(),
+            userDetails.getUserAuthority().name()
+        ));
+    }
+
     public record TokenInfoResponse(
         Long userId,
         String username,
         String authority
-    ) {}
+    ) {
+
+    }
+
+    public record mockUserInfo(
+        Long userId,
+        String username,
+        String authority
+    ) {
+
+    }
 }


### PR DESCRIPTION
## PR 내용

- [test: 테스트 코드에서 인증 객체 통과를 위한 어노테이션 작성 및 예시코드 작성](https://github.com/Sparta-21/TDD/commit/5991e6a7c7bae926cf5198a48b226d7d50c3ba0a)
  - 슬랙에 작성해둔 내용처럼 통합테스트 / 컨트롤러 테스트 작성 시에 인증 객체를 설정하기 위한 별도의 비용이 들어갑니다.
  - 간단한 인증 객체 사용을 위해 `@CustomWithMockUser` 어노테이션을 작성했습니다.
  - id, username, authority 를 개별 설정 가능해, 테스트 내용에 맞게 커스텀이 가능합니다.
  - 별도의 `CustomWithMockUserSecurityContextFactory`을 통해 test 환경에서 `@CustomWithMockUser` 데이터 기반 UserDetailsImpl을 생성 후 인증 객체를 SecurityContext에 담게 됩니다.
  - `CustomWithMockUserExampleTest` 및 `TestAuthController`을 통해 예시 코드를 구성해봤습니다.

- [config: TestContainer 사용을 위한 의존성 추가](https://github.com/Sparta-21/TDD/commit/a1034d49acc3957874352e4cebe675d2c0460f69)
  - 현재 팀원분들께서 `@DataJpaTest` 환경에서 인메모리 DB인 h2 대신 `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)`을 적용해 실제 DB와의 연동 환경을 구성해주고 계십니다.
  - 이는, DB 간의 차이로 인해 올바른 테스트 결과를 보장할 수 없기 때문에 postgresql을 사용하고 있습니다.
  - 하지만, 데이터 간의 독립성을 가지기 위해서는 별도의 테스트 전용 DB 구성을 하는 것이 좋을 것 같다는 생각을 했습니다.
  - TestContainer 적용을 통해 실제 개발 DB와는 별도로 테스트 환경 전용에서만 DB를 구성해 개발 DB의 데이터에 영향을 주지 않는 방법을 적용했습니다.

- [test: TestContainer을 활용한 통합테스트, Repository 테스트 템플릿 구성](https://github.com/Sparta-21/TDD/commit/dc32b16e1f48d7a41a404b86cfb4537fe5e68fe7)
  - 매번 테스트 작성시마다 테스트 클래스 상단에 어노테이션을 통해 환경을 구성하게 되는데, 이를 템플릿으로 간단한 상속만으로 적용할 수 있도록 했습니다.
  - 또한 테스트 환경에서는 `local` 프로필이 아니라 `test` 프로필을 이용해 TesContainer Postgresql과 연결하며, hibernate의 create-drop 을 통해, 개별 테스트마다 독립적인 환경을 구성하도록 설정했습니다.
  - 하나의 클래스 내부에서도 각 테스트 간 올바른 결과를 구성하기 위해 DB 데이터가 독립될 필요성을 느껴, `CleanUp.all()` 메소드를 통해 테스트가 실행되기 이전마다 `@BeforeEach` 를 통해 DB 데이터를 초기화하도록 설정했습니다.
  - `CleanUp.all()` 메소드는 `@Entity`,`@Table` 어노테이션 옵션을 기반으로 진행되기 때문에, Entity가 추가되어도 동적으로 동작하게 됩니다.
  - 만약 테스트가 연쇄적으로 동작해 `CleanUp.all()` 메소드를 적용하지 않아야 하는 경우
```java
@Override
@BeforeEach
protected void setUp() {
    // cleanUp을 호출하지 않음 (빈 메서드)
}

@Override
@BeforeEach
protected void setUp() {
    super.setUp();
    System.out.println("hello world"); // 필요한 초기 작업 작성
}
```
  - 위와 같이 구성해 동작하지 않도록 하거나, super을 이용해 추가적인 초기 작업을 구성할 수 있습니다.
  - `AuthIntegrationTest` 변경사항으로 예시를 적용했습니다.

## 리뷰 내용
- TestContainer 및 템플릿은 커스텀 어노테이션 적용 이후, 남은 프로젝트 기간 동안 계속해서 작성되는 테스트 작성 시 불필요한 비용을 줄이고자 추가해봤습니다. 이 부분은 의견을 나눠보고 적용을 할지말지 정하고자 합니다. 의견들 남겨주세요!