### PR TITLE
refactor(store): 메뉴/스토어 검색 로직을 단일 쿼리 기반으로 통합하고 페이징 계산 개선

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/menu/dto/MenuWithStoreResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/dto/MenuWithStoreResponseDto.java
@@ -2,6 +2,7 @@ package com.sparta.tdd.domain.menu.dto;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
+import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.menu.entity.QMenu;
 import java.util.UUID;
 import lombok.Builder;
@@ -28,5 +29,14 @@ public record MenuWithStoreResponseDto(
             menu.isHidden,
             menu.store.id
         );
+    }
+
+    public static MenuWithStoreResponseDto from(Menu menu) {
+        return MenuWithStoreResponseDto.builder()
+            .menuId(menu.getId())
+            .name(menu.getName())
+            .price(menu.getPrice())
+            .description(menu.getDescription())
+            .build();
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/sparta/tdd/domain/store/dto/StoreResponseDto.java
@@ -37,6 +37,7 @@ public record StoreResponseDto(
             .imageUrl(store.getImageUrl())
             .avgRating(store.getAvgRating())
             .reviewCount(store.getReviewCount())
+            .menus(new ArrayList<>())
             .build();
     }
 

--- a/src/main/java/com/sparta/tdd/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/tdd/domain/store/entity/Store.java
@@ -1,10 +1,8 @@
 package com.sparta.tdd.domain.store.entity;
 
-import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.global.model.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,11 +13,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -60,12 +55,9 @@ public class Store extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Menu> menuList = new ArrayList<>();
-
     @Builder
     public Store(String name, StoreCategory category, String description, String imageUrl,
-        User user, List<Menu> menuList) {
+        User user) {
         this.name = name;
         this.category = category;
         this.description = description;
@@ -73,7 +65,6 @@ public class Store extends BaseEntity {
         this.avgRating = BigDecimal.ZERO;
         this.reviewCount = 0;
         this.user = user;
-        this.menuList = menuList;
     }
 
     public void updateName(String updatedName) {

--- a/src/main/java/com/sparta/tdd/domain/store/enums/StoreCategory.java
+++ b/src/main/java/com/sparta/tdd/domain/store/enums/StoreCategory.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum StoreCategory  {
+public enum StoreCategory {
     KOREAN("한식"),
     CHINESE("중식"),
     JAPANESE("일식"),

--- a/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryCustom.java
@@ -1,17 +1,17 @@
 package com.sparta.tdd.domain.store.repository;
 
-import com.sparta.tdd.domain.store.dto.StoreResponseDto;
+import com.querydsl.core.Tuple;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StoreRepositoryCustom {
 
-    List<UUID> findStoreIdsByMenuKeyword(String keyword, StoreCategory storeCategory);
+    List<UUID> findPagedStoreIdsByKeyword(Pageable pageable, String keyword,
+        StoreCategory storeCategory);
 
-    List<UUID> findStoreIdsByStoreNameKeyword(String keyword, StoreCategory storeCategory);
+    List<Tuple> findStoresWithMenusByIds(List<UUID> storeIds);
 
-    Page<StoreResponseDto> findStoresByIds(List<UUID> storeIds, Pageable pageable);
+    Long countStoresByKeyword(String keyword, StoreCategory storeCategory);
 }

--- a/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImpl.java
@@ -70,19 +70,28 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
         return PageableExecutionUtils.getPage(stores, pageable, countQuery::fetchOne);
     }
 
-    private BooleanBuilder buildStoreFilter(String keyword, StoreCategory storeCategory,
-        boolean includeStoreName) {
+    private BooleanExpression storeNameLike(String keyword) {
         QStore store = QStore.store;
-        BooleanBuilder builder = new BooleanBuilder();
+        return keyword != null ? store.name.containsIgnoreCase(keyword) : null;
+    }
 
-        if (includeStoreName && keyword != null && !keyword.isBlank()) {
-            builder.and(store.name.containsIgnoreCase(keyword));
-        }
+    private BooleanExpression menuNameLike(String keyword) {
+        QMenu menu = QMenu.menu;
+        return keyword != null ? menu.name.containsIgnoreCase(keyword) : null;
+    }
 
-        if (storeCategory != null) {
-            builder.and(store.category.eq(storeCategory));
-        }
+    private BooleanExpression storeCategoryEq(StoreCategory storeCategory) {
+        QStore store = QStore.store;
+        return storeCategory != null ? store.category.eq(storeCategory) : null;
+    }
 
-        return builder;
+    private BooleanExpression storeIsNotDeleted() {
+        QStore store = QStore.store;
+        return store.deletedAt.isNull();
+    }
+
+    private BooleanExpression menuIsNotHidden() {
+        QMenu menu = QMenu.menu;
+        return menu.isHidden.isFalse();
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/tdd/domain/store/service/StoreService.java
@@ -1,6 +1,10 @@
 package com.sparta.tdd.domain.store.service;
 
+import static com.sparta.tdd.domain.store.entity.QStore.store;
+
+import com.querydsl.core.Tuple;
 import com.sparta.tdd.domain.menu.dto.MenuWithStoreResponseDto;
+import com.sparta.tdd.domain.menu.entity.QMenu;
 import com.sparta.tdd.domain.menu.repository.MenuRepository;
 import com.sparta.tdd.domain.store.dto.StoreRequestDto;
 import com.sparta.tdd.domain.store.dto.StoreResponseDto;
@@ -11,13 +15,14 @@ import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,35 +36,47 @@ public class StoreService {
     private final UserRepository userRepository;
     private final MenuRepository menuRepository;
 
-    // TODO: 정렬 추가 (별점 순)
     public Page<StoreResponseDto> searchStoresByKeywordAndCategoryWithMenus(String keyword,
         StoreCategory storeCategory,
         Pageable pageable) {
 
-        List<UUID> menuMatched = storeRepository.findStoreIdsByMenuKeyword(keyword, storeCategory);
-        List<UUID> storeMatched = storeRepository.findStoreIdsByStoreNameKeyword(keyword,
+        List<UUID> storeIds = storeRepository.findPagedStoreIdsByKeyword(pageable, keyword,
             storeCategory);
 
-        LinkedHashSet<UUID> searchedIds = new LinkedHashSet<>();
-        searchedIds.addAll(menuMatched);
-        searchedIds.addAll(storeMatched);
-
-        if (searchedIds.isEmpty()) {
+        if (storeIds.isEmpty()) {
             return Page.empty(pageable);
         }
 
-        List<UUID> storeIds = new ArrayList<>(searchedIds);
+        List<Tuple> tuples = storeRepository.findStoresWithMenusByIds(storeIds);
 
-        Page<StoreResponseDto> stores = storeRepository.findStoresByIds(storeIds, pageable);
+        Map<UUID, List<MenuWithStoreResponseDto>> menus = tuples.stream()
+            .filter(tuple -> Objects.nonNull(tuple.get(QMenu.menu)))
+            .collect(Collectors.groupingBy(
+                tuple -> Objects.requireNonNull(tuple.get(store)).getId(),
+                Collectors.mapping(
+                    tuple -> MenuWithStoreResponseDto.from(
+                        Objects.requireNonNull(tuple.get(QMenu.menu))),
+                    Collectors.toList()
+                )
+            ));
 
-        List<UUID> pagedStoreIds = stores.getContent().stream()
-            .map(StoreResponseDto::id)
+        List<StoreResponseDto> stores = tuples.stream()
+            .map(tuple -> tuple.get(store))
+            .filter(Objects::nonNull)
+            .distinct()
+            .map(StoreResponseDto::from)
+            .map(storeResponseDto -> storeResponseDto.withMenus(
+                menus.getOrDefault(storeResponseDto.id(), List.of())))
             .toList();
 
-        Map<UUID, List<MenuWithStoreResponseDto>> menuMap = menuRepository.findByStoreIds(
-            pagedStoreIds);
+        long totalCount;
+        if (stores.size() < pageable.getPageSize()) {
+            totalCount = pageable.getOffset() + stores.size();
+        } else {
+            totalCount = storeRepository.countStoresByKeyword(keyword, storeCategory);
+        }
 
-        return stores.map(store -> store.withMenus(menuMap.getOrDefault(store.id(), List.of())));
+        return new PageImpl<>(stores, pageable, totalCount);
     }
 
     @Transactional


### PR DESCRIPTION
[refactor(store): 메뉴/스토어 검색 로직을 단일 쿼리 기반으로 통합하고 페이징 계산 개선](https://github.com/Sparta-21/TDD/commit/163d701753a4cfd7eea4c9a828eded6071bf2b8d)
### 수정 전

- 기존에는 메뉴/스토어 각각 키워드 검색 후, 결과 storeId 목록으로 다시 스토어 및 메뉴를 재조회하는 구조

### 수정 후 

- 이를 단일 쿼리(findPagedStoreIdsByKeyword) 기반으로 통합하여
 - 키워드 필터링
 - 페이징 처리조회 된 ID를 기준으로 스토어 및 메뉴를 한 번에 조회하도록 개선
- 전체 쿼리 호출 횟수 감소 및 로직 단순화로 성능·가독성 향상

### 기대 효과
- DB 호출 3회 → 2회로 감소

[refactor(store): BooleanBuilder 기반 쿼리를 BooleanExpression 기반 구조로 개선](https://github.com/Sparta-21/TDD/commit/ebcd831c4f7771359a1b75d9d8be27bcf3322bb8)
### 수정 전
- QueryDSL BooleanBuilder 기반의 복잡한 조건문
### 수정 후 
- 명확한 메서드 단위의 BooleanExpression 구조로 리팩터링
- 필터링 조건(storeIsNotDeleted, menuIsNotHidden) 추가로 삭제된 스토어 / 숨김 처리된 메뉴 가 검색되지 않도록 보완

### 기대 효과
- 가독성 및 재사용성 향상
-
[refactor(store): menu, store 양방향 관계 제거](https://github.com/Sparta-21/TDD/commit/91af8f3bec79b56ba7213169adf724a0336dc535)
- menu, store 양방향 관계 제거