### PR TITLE
feat(user): 주문, 리뷰 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,6 +41,9 @@ public interface OrderRepository extends JpaRepository<Order, UUID>, OrderReposi
           where o.id in :ids
         """)
     List<Order> findDetailsByIdIn(Collection<UUID> ids);
+
+    @Query("SELECT o FROM Order o WHERE o.user.id = :userId AND o.deletedAt IS NULL")
+    Page<Order> findOrdersByUserIdAndNotDeleted(@Param("userId") Long userId, Pageable pageable);
 }
 
 

--- a/src/main/java/com/sparta/tdd/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/tdd/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sparta.tdd.domain.user.controller;
 
 import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import com.sparta.tdd.domain.order.dto.OrderResponseDto;
 import com.sparta.tdd.domain.review.dto.ReviewResponseDto;
 import com.sparta.tdd.domain.user.dto.*;
 import com.sparta.tdd.domain.user.service.UserService;
@@ -76,6 +77,14 @@ public class UserController {
     public ResponseEntity<Page<ReviewResponseDto>> getUserReviewsByUserId(@PathVariable("userId") Long userId,
                                                                           @PageableDefault Pageable pageable) {
         Page<ReviewResponseDto> responseDto = userService.getPersonalReviews(userId, pageable);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{userId}/orders")
+    @Operation(summary = "유저 주문 목록 조회")
+    public ResponseEntity<Page<OrderResponseDto>> getUserOrdersByUserId(@PathVariable("userId") Long userId,
+                                                                        @PageableDefault Pageable pageable) {
+        Page<OrderResponseDto> responseDto = userService.getPersonalOrders(userId, pageable);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/tdd/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sparta.tdd.domain.user.controller;
 
 import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import com.sparta.tdd.domain.review.dto.ReviewResponseDto;
 import com.sparta.tdd.domain.user.dto.*;
 import com.sparta.tdd.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -65,6 +67,15 @@ public class UserController {
     @Operation(summary = "유저 매니저 권한 부여")
     public ResponseEntity<UserResponseDto> updateManagerAuthorityUser(@PathVariable("userId") Long userId) {
         UserResponseDto responseDto = userService.grantUserManagerAuthority(userId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 회원 리뷰 목록 조회
+    @GetMapping("/{userId}/reviews")
+    @Operation(summary = "유저 리뷰 목록 조회")
+    public ResponseEntity<Page<ReviewResponseDto>> getUserReviewsByUserId(@PathVariable("userId") Long userId,
+                                                                          @PageableDefault Pageable pageable) {
+        Page<ReviewResponseDto> responseDto = userService.getPersonalReviews(userId, pageable);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/tdd/domain/user/service/UserService.java
@@ -84,7 +84,7 @@ public class UserService {
     // 리뷰 목록 조회
     public Page<ReviewResponseDto> getPersonalReviews(Long userId, Pageable pageable) {
         List<Review> reviewList = reviewRepository.findByUserIdAndNotDeleted(userId);
-        PageImpl<Review> reviews = new PageImpl<>(reviewList, pageable, reviewList.size());
+        Page<Review> reviews = new PageImpl<>(reviewList, pageable, reviewList.size());
         return reviews.map(ReviewResponseDto::from);
     }
 

--- a/src/main/java/com/sparta/tdd/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/tdd/domain/user/service/UserService.java
@@ -1,14 +1,14 @@
 package com.sparta.tdd.domain.user.service;
 
+import com.sparta.tdd.domain.review.dto.ReviewResponseDto;
+import com.sparta.tdd.domain.review.entity.Review;
+import com.sparta.tdd.domain.review.repository.ReviewRepository;
 import com.sparta.tdd.domain.user.dto.*;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +21,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
     private final PasswordEncoder passwordEncoder;
     // 회원 목록 조회
     public Page<UserResponseDto> getAllUsers(Pageable pageable) {
@@ -73,6 +74,12 @@ public class UserService {
         user.updateAuthority(UserAuthority.MANAGER);
 
         return UserResponseDto.from(user);
+    }
+    // 리뷰 목록 조회
+    public Page<ReviewResponseDto> getPersonalReviews(Long userId, Pageable pageable) {
+        List<Review> reviewList = reviewRepository.findByUserIdAndNotDeleted(userId);
+        PageImpl<Review> reviews = new PageImpl<>(reviewList, pageable, reviewList.size());
+        return reviews.map(ReviewResponseDto::from);
     }
     private User getUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(

--- a/src/test/java/com/sparta/tdd/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/user/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.sparta.tdd.domain.user.service;
 
+import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.repository.OrderRepository;
 import com.sparta.tdd.domain.review.entity.Review;
 import com.sparta.tdd.domain.review.repository.ReviewRepository;
 import com.sparta.tdd.domain.user.dto.UserNicknameRequestDto;
@@ -31,6 +33,8 @@ class UserServiceTest {
     UserRepository userRepository;
     @Mock
     ReviewRepository reviewRepository;
+    @Mock
+    OrderRepository orderRepository;
     @InjectMocks
     UserService userService;
 
@@ -189,6 +193,49 @@ class UserServiceTest {
         assertFalse(reviews.stream().anyMatch(review -> {
             return review.getContent().equals("맛있는지 모르겠어요.");
         }));
+    }
+
+    @Test
+    @DisplayName("유저 주문 목록 조회 성공")
+    public void findOrdersByUserSuccess() {
+        // given
+        User user = mock(User.class);
+        Pageable pageable = mock(Pageable.class);
+        Order order1 = mock(Order.class);
+        Order order2 = mock(Order.class);
+        Order order3 = mock(Order.class);
+
+        when(user.getId()).thenReturn(1L);
+        when(orderRepository.findOrdersByUserIdAndNotDeleted(anyLong())).thenReturn(List.of(order1, order2, order3));
+
+        // when
+        List<Order> orderList = orderRepository.findOrdersByUserIdAndNotDeleted(user.getId());
+        PageImpl<Order> orders = new PageImpl<>(orderList, pageable, orderList.size());
+
+        // then
+        assertEquals(orders.getTotalElements(), 3);
+
+    }
+
+    @Test
+    @DisplayName("유저 주문 목록 조회 실패")
+    public void findOrdersByUserFail() {
+        // given
+        User user = mock(User.class);
+        Pageable pageable = mock(Pageable.class);
+        Order order1 = mock(Order.class);
+        Order order2 = mock(Order.class);
+        Order order3 = mock(Order.class);
+
+        when(user.getId()).thenReturn(1L);
+        when(orderRepository.findOrdersByUserIdAndNotDeleted(anyLong())).thenReturn(List.of(order1, order2, order3));
+
+        // when
+        List<Order> orderList = orderRepository.findOrdersByUserIdAndNotDeleted(user.getId());
+        PageImpl<Order> orders = new PageImpl<>(orderList, pageable, orderList.size());
+
+        // then
+        assertFalse(orders.getTotalElements() == 2);
     }
     User createUser(String username, String password, String nickname, UserAuthority authority) {
         return User.builder()


### PR DESCRIPTION
저는 긴 연휴덕에 아직 정신을 못차리고 있는 것 같습니다.. 얼른 정신차려보도록 하겠습니다.
### PR 내용
---- 
[feat(user): 유저 주문 목록 조회 기능 추가](https://github.com/Sparta-21/TDD/commit/e6bcff2934ff006ad22467a79271b29d8de9a33c)
- 유저의 주문 목록을 페이징 조회하는 기능을 추가하였습니다.
- User의 Id로 `Page<Order>`를 받아오는 메서드가 없어 추가하였습니다.

[feat(user): 유저 리뷰 목록 조회 기능 추가](https://github.com/Sparta-21/TDD/commit/29ccd2c2c75c66da2f9276111be26806bf6c2425)
- 유저의 리뷰 목록을 페이징 조회하는 기능을 추가하였습니다.
- ReviewRepository의 `findByUserIdAndNotDeleted()` 메서드를 재사용하여 `List<Review>`를 조회한 뒤, `new PageImpl<>(list, pageable, list.size())` 형태로 후처리해주었습니다.
