### PR TITLE
feat(common): 기존의 표준 예외를 공통된 비즈니스 예외로 전환

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/tdd/domain/auth/service/AuthService.java
@@ -88,7 +88,7 @@ public class AuthService {
     @Transactional
     public void withdrawal(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         LocalDateTime deletedAt = LocalDateTime.now();
 

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -16,6 +16,8 @@ import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 
 import java.util.*;
 import java.util.function.Function;
@@ -65,7 +67,7 @@ public class OrderService {
 
         if (UserAuthority.isCustomer(userDetails.getUserAuthority())
         && !userDetails.getUserId().equals(searchOption.userId())) {
-            throw new IllegalArgumentException("권한이 없습니다");
+            throw new BusinessException(ErrorCode.ORDER_PERMISSION_DENIED);
         }
 
     }
@@ -76,7 +78,7 @@ public class OrderService {
 
         if (UserAuthority.isCustomer(userDetails.getUserAuthority())
                 && !userDetails.getUserId().equals(userId)) {
-            throw new IllegalArgumentException("권한이 없습니다");
+            throw new BusinessException(ErrorCode.ORDER_PERMISSION_DENIED);
         }
 
     }
@@ -86,7 +88,7 @@ public class OrderService {
         UUID orderId) {
 
         Order order = orderRepository.findDetailById(orderId)
-            .orElseThrow(() -> new IllegalArgumentException("주문내역을 찾을 수 없습니다"));
+            .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         hasPermission(userDetails, order.getUser().getId());
 
@@ -126,7 +128,7 @@ public class OrderService {
             List<Menu> menus,
             Set<UUID> menuIdsFromDto) {
         if (menus.size() != menuIdsFromDto.size()) {
-            throw new IllegalArgumentException("메뉴 정보가 올바르지 않습니다");
+            throw new BusinessException(ErrorCode.MENU_INVALID_INFO);
         }
     }
 
@@ -141,6 +143,6 @@ public class OrderService {
      */
     private <T, ID> T findEntity(JpaRepository<T, ID> jpaRepository, ID id) {
         return jpaRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 id 입니다"));
+            .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -15,6 +15,8 @@ import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +77,7 @@ public class OrderService {
 
     public OrderResponseDto getOrder(UserDetailsImpl userDetails, UUID orderId) {
         Order order = orderRepository.findDetailById(orderId)
-            .orElseThrow(() -> new IllegalArgumentException("주문내역을 찾을 수 없습니다"));
+            .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         OrderResponseDto resDto = orderMapper.toResponse(order);
 
@@ -88,10 +90,10 @@ public class OrderService {
         OrderRequestDto reqDto) {
 
         User foundUser = userRepository.findById(userDetails.getUserId())
-            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         Store foundStore = storeRepository.findByName(reqDto.storeName())
-            .orElseThrow(() -> new IllegalArgumentException("가게이름을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
         Order order = orderMapper.toOrder(reqDto);
         order.assignUser(foundUser);
@@ -112,7 +114,7 @@ public class OrderService {
             Menu menu = menuMap.get(om.menuId());
 
             if (!menu.getStore().getId().equals(foundStore.getId())) {
-                throw new IllegalArgumentException("해당 가게의 메뉴가 아닙니다: menuId=" + om.menuId());
+                throw new BusinessException(ErrorCode.MENU_NOT_IN_STORE, "해당 가게의 메뉴가 아닙니다: menuId=" + om.menuId());
             }
 
             OrderMenu orderMenu = OrderMenu.builder()
@@ -141,7 +143,7 @@ public class OrderService {
             // 어떤 id가 빠졌는지 알려주면 디버깅에 좋음
             List<UUID> missing = new ArrayList<>(menuIds);
             missing.removeAll(menuMap.keySet());
-            throw new IllegalArgumentException("존재하지 않는 메뉴가 포함되어 있습니다: " + missing);
+            throw new BusinessException(ErrorCode.MENU_NOT_FOUND, "존재하지 않는 메뉴가 포함되어 있습니다: " + missing);
         }
     }
 

--- a/src/main/java/com/sparta/tdd/domain/review/service/ReviewReplyService.java
+++ b/src/main/java/com/sparta/tdd/domain/review/service/ReviewReplyService.java
@@ -11,6 +11,8 @@ import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -66,42 +68,42 @@ public class ReviewReplyService {
     private void checkReplyExists(UUID reviewId) {
         reviewReplyRepository.findByReviewIdAndNotDeleted(reviewId)
                 .ifPresent(reply -> {
-                    throw new IllegalArgumentException("이미 답글이 존재합니다.");
+                    throw new BusinessException(ErrorCode.REVIEW_REPLY_ALREADY_EXISTS);
                 });
     }
 
     // 리뷰 ID로 삭제되지 않은 리뷰 조회
     private Review findReviewById(UUID reviewId) {
         return reviewRepository.findByIdAndNotDeleted(reviewId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
     }
 
     //리뷰 ID로 삭제되지 않은 답글 조회
     private ReviewReply findReplyById(UUID reviewId) {
         return reviewReplyRepository.findByReviewIdAndNotDeleted(reviewId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답글입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_REPLY_NOT_FOUND));
     }
 
     private void checkIfOwner(UUID storeId, Long userId) {
         Store store = storeRepository.findByStoreIdAndNotDeleted(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 수정은 MANAGER/MASTER도 불가, 오직 가게 소유자만 가능
         if (!store.isOwner(user)) {
-            throw new IllegalArgumentException("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+            throw new BusinessException(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED);
         }
     }
 
     //가게 소유자 검증
     private void checkAuthority(UUID storeId, Long userId) {
         Store store = storeRepository.findByStoreIdAndNotDeleted(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가게입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // MANAGER나 MASTER면 통과, OWNER면 가게 소유자 확인
         if (user.getAuthority() == UserAuthority.MANAGER || user.getAuthority() == UserAuthority.MASTER) {
@@ -109,7 +111,7 @@ public class ReviewReplyService {
         }
 
         if (!store.isOwner(user)) {
-            throw new IllegalArgumentException("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+            throw new BusinessException(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED);
         }
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/store/service/StoreService.java
+++ b/src/main/java/com/sparta/tdd/domain/store/service/StoreService.java
@@ -9,7 +9,8 @@ import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -102,23 +103,23 @@ public class StoreService {
 
     private Store getStoreById(UUID storeId) {
         return storeRepository.findByStoreIdAndNotDeleted(storeId)
-            .orElseThrow(() -> new EntityNotFoundException("상점이 존재하지 않습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
     }
 
     private User getUserById(Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new EntityNotFoundException("유저가 존재하지 않습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     private void validateStorePermission(User user) {
         if (!user.isOwnerLevel()) {
-            throw new IllegalArgumentException("상점 관련 작업을 수행할 권한이 없습니다.");
+            throw new BusinessException(ErrorCode.STORE_PERMISSION_DENIED);
         }
     }
 
     private void validateStoreOwnership(User user, Store store) {
         if (!store.isOwner(user) && !user.isManagerLevel()) {
-            throw new IllegalArgumentException("본인의 상점만 수정/삭제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.STORE_OWNERSHIP_DENIED);
         }
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/tdd/domain/user/service/UserService.java
@@ -1,39 +1,42 @@
 package com.sparta.tdd.domain.user.service;
 
-import com.sparta.tdd.domain.user.dto.*;
+import com.sparta.tdd.domain.user.dto.UserNicknameRequestDto;
+import com.sparta.tdd.domain.user.dto.UserPasswordRequestDto;
+import com.sparta.tdd.domain.user.dto.UserResponseDto;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
     // 회원 목록 조회
     public Page<UserResponseDto> getAllUsers(Pageable pageable) {
         Page<User> userList = userRepository.findAll(pageable);
 
         return userList.map(UserResponseDto::from);
     }
+
     // 회원 정보 조회
     public UserResponseDto getUserByUserId(Long userId) {
         User user = getUserById(userId);
 
         return UserResponseDto.from(user);
     }
+
     // 회원 닉네임 수정
     @Transactional
     public UserResponseDto updateUserNickname(Long userId, Long updateId, UserNicknameRequestDto requestDto) {
@@ -41,12 +44,13 @@ public class UserService {
         User user = getUserById(userId);
 
         if (user.getNickname().equals(requestDto.nickname())) {
-            throw new IllegalArgumentException("이미 사용중인 닉네임입니다.");
+            throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
         user.updateNickname(requestDto.nickname());
 
         return UserResponseDto.from(user);
     }
+
     // 회원 비밀번호 수정
     @Transactional
     public UserResponseDto updateUserPassword(Long userId, Long updateId, UserPasswordRequestDto requestDto) {
@@ -54,34 +58,37 @@ public class UserService {
         User user = getUserById(userId);
 
         if (passwordEncoder.matches(requestDto.password(), user.getPassword())) {
-            throw new IllegalArgumentException("이미 사용중인 비밀번호입니다.");
+            throw new BusinessException(ErrorCode.SAME_PASSWORD);
         }
 
         user.updatePassword(passwordEncoder.encode(requestDto.password()));
 
         return UserResponseDto.from(user);
     }
+
     // 매니저 권한 부여
     @Transactional
     public UserResponseDto grantUserManagerAuthority(Long userId) {
         User user = getUserById(userId);
 
         if (user.getAuthority() == UserAuthority.MANAGER) {
-            throw new IllegalArgumentException("이미 매니저 권한입니다.");
+            throw new BusinessException(ErrorCode.ALREADY_MANAGER);
         }
 
         user.updateAuthority(UserAuthority.MANAGER);
 
         return UserResponseDto.from(user);
     }
+
     private User getUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않는 회원입니다.")
+            () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
         );
     }
+
     private void isValidUser(Long userId, Long validId) {
         if (userId != validId) {
-            throw new IllegalArgumentException("다른 사용자의 정보를 수정할 수 없습니다.");
+            throw new BusinessException(ErrorCode.CANNOT_MODIFY_OTHER_MEMBER);
         }
     }
 }

--- a/src/main/java/com/sparta/tdd/global/exception/BusinessException.java
+++ b/src/main/java/com/sparta/tdd/global/exception/BusinessException.java
@@ -1,0 +1,24 @@
+package com.sparta.tdd.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
@@ -1,0 +1,61 @@
+package com.sparta.tdd.global.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, "요청이 현재 서버 상태와 충돌합니다."),
+
+    // AUTH 도메인 관련
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "액세스 토큰이 존재하지 않습니다."),
+    ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "금지된 액세스 토큰입니다."),
+    ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "금지된 리프레시 토큰입니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "올바르지 않은 요청입니다."),
+    USERNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 username 입니다."),
+
+    // USER 도메인 관련
+    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "이미 사용중인 비밀번호입니다."),
+    ALREADY_MANAGER(HttpStatus.BAD_REQUEST, "이미 매니저 권한입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    CANNOT_MODIFY_OTHER_MEMBER(HttpStatus.FORBIDDEN, "다른 사용자의 정보를 수정할 수 없습니다."),
+
+    // STORE 도메인 관련
+    STORE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "상점 관련 작업을 수행할 권한이 없습니다."),
+    STORE_OWNERSHIP_DENIED(HttpStatus.FORBIDDEN, "본인의 상점만 수정/삭제할 수 있습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상점입니다."),
+
+    // ORDER 도메인 관련
+    MENU_NOT_IN_STORE(HttpStatus.BAD_REQUEST, "해당 가게의 메뉴가 아닙니다."),
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 메뉴가 포함되어 있습니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
+
+    // MENU 도메인 관련
+
+    // REVIEW 도메인 관련
+    REVIEW_NOT_OWNED(HttpStatus.FORBIDDEN, "본인의 리뷰만 수정/삭제할 수 있습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리뷰입니다."),
+    REVIEW_REPLY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 답글이 존재합니다."),
+    REVIEW_REPLY_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 가게의 소유자만 답글을 작성할 수 있습니다."),
+    REVIEW_REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 답글입니다."),
+
+    // PAYMENT 도메인 관련
+
+    // AI 도메인 관련
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     CONFLICT(HttpStatus.CONFLICT, "요청이 현재 서버 상태와 충돌합니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 id 입니다."),
 
     // AUTH 도메인 관련
     ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "액세스 토큰이 존재하지 않습니다."),
@@ -38,8 +39,10 @@ public enum ErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 상점입니다."),
 
     // ORDER 도메인 관련
+    ORDER_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     MENU_NOT_IN_STORE(HttpStatus.BAD_REQUEST, "해당 가게의 메뉴가 아닙니다."),
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 메뉴가 포함되어 있습니다."),
+    MENU_INVALID_INFO(HttpStatus.BAD_REQUEST, "메뉴 정보가 올바르지 않습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
 
     // MENU 도메인 관련

--- a/src/main/java/com/sparta/tdd/global/exception/ErrorResponse.java
+++ b/src/main/java/com/sparta/tdd/global/exception/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.sparta.tdd.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final String error;
+    private final String message;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+            .error(errorCode.name())
+            .message(errorCode.getMessage())
+            .build();
+    }
+
+    public static ErrorResponse of(String error, String message) {
+        return ErrorResponse.builder()
+            .error(error)
+            .message(message)
+            .build();
+    }
+}

--- a/src/main/java/com/sparta/tdd/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/tdd/global/exception/GlobalExceptionHandler.java
@@ -18,6 +18,16 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.warn("handleBusinessException : {}", e.getMessage());
+        
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().name(), e.getMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+            .body(errorResponse);
+    }
+
     @ExceptionHandler({
         MethodArgumentNotValidException.class,
         MissingServletRequestParameterException.class,

--- a/src/main/java/com/sparta/tdd/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/tdd/global/exception/GlobalExceptionHandler.java
@@ -22,40 +22,50 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.warn("handleBusinessException : {}", e.getMessage());
-        
+
         ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().name(), e.getMessage());
 
         return ResponseEntity.status(e.getErrorCode().getStatus())
             .body(errorResponse);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("handleMethodArgumentNotValidException : {}", e.getMessage());
+
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+            .map(fieldError -> fieldError.getDefaultMessage())
+            .findFirst()
+            .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorMessage);
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<String> handleBindException(BindException e) {
+        log.warn("handleBindException : {}", e.getMessage());
+
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+            .map(fieldError -> fieldError.getDefaultMessage())
+            .findFirst()
+            .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorMessage);
+    }
+
     @ExceptionHandler({
-        MethodArgumentNotValidException.class,
         MissingServletRequestParameterException.class,
         MissingRequestHeaderException.class,
-        BindException.class,
         TypeMismatchException.class,
         MethodArgumentTypeMismatchException.class
     })
     protected ResponseEntity<String> handleValidException(Exception e) {
         log.warn("handleValidException : {}", e.getMessage());
 
-        String errorMessage = "잘못된 요청입니다.";
-
-        if (e instanceof MethodArgumentNotValidException validException) {
-            errorMessage = validException.getBindingResult().getFieldErrors().stream()
-                .map(fieldError -> fieldError.getDefaultMessage())
-                .findFirst()
-                .orElse("잘못된 요청입니다.");
-        } else if (e instanceof BindException bindException) {
-            errorMessage = bindException.getBindingResult().getFieldErrors().stream()
-                .map(fieldError -> fieldError.getDefaultMessage())
-                .findFirst()
-                .orElse("잘못된 요청입니다.");
-        }
-
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(errorMessage);
+            .body("잘못된 요청입니다.");
     }
 
     @ExceptionHandler({

--- a/src/main/java/com/sparta/tdd/global/jwt/JwtTokenValidator.java
+++ b/src/main/java/com/sparta/tdd/global/jwt/JwtTokenValidator.java
@@ -1,6 +1,8 @@
 package com.sparta.tdd.global.jwt;
 
 import com.sparta.tdd.domain.auth.service.TokenBlacklistService;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import com.sparta.tdd.global.jwt.provider.AccessTokenProvider;
 import com.sparta.tdd.global.jwt.provider.RefreshTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -16,31 +18,31 @@ public class JwtTokenValidator {
 
     public void validateAccessToken(String accessToken) {
         if (accessToken == null || accessToken.isEmpty()) {
-            throw new IllegalArgumentException("액세스 토큰이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.ACCESS_TOKEN_NOT_FOUND);
         }
 
         if (tokenBlacklistService.isAccessTokenBlacklisted(accessToken)) {
-            throw new IllegalArgumentException("금지된 액세스 토큰입니다.");
+            throw new BusinessException(ErrorCode.ACCESS_TOKEN_BLACKLISTED);
         }
 
         String tokenType = accessTokenProvider.getTokenType(accessToken);
         if (!"access".equals(tokenType) || !accessTokenProvider.validateToken(accessToken)) {
-            throw new IllegalArgumentException("유효하지 않은 액세스 토큰입니다.");
+            throw new BusinessException(ErrorCode.ACCESS_TOKEN_INVALID);
         }
     }
 
     public void validateRefreshToken(String refreshToken) {
         if (refreshToken == null || refreshToken.isEmpty()) {
-            throw new IllegalArgumentException("리프레시 토큰이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
         if (tokenBlacklistService.isRefreshTokenBlacklisted(refreshToken)) {
-            throw new IllegalArgumentException("금지된 리프레시 토큰입니다.");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_BLACKLISTED);
         }
 
         String tokenType = refreshTokenProvider.getTokenType(refreshToken);
         if (!"refresh".equals(tokenType) || !refreshTokenProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
         }
     }
 }

--- a/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
@@ -3,6 +3,7 @@ package com.sparta.tdd.common.template;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.tdd.common.config.TestContainerConfig;
 import com.sparta.tdd.common.helper.CleanUp;
+import com.sparta.tdd.global.config.QueryDSLConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,7 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@Import(TestContainerConfig.class)
+@Import({TestContainerConfig.class, QueryDSLConfig.class})
 public abstract class IntegrationTest {
 
     @Autowired

--- a/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
@@ -3,6 +3,7 @@ package com.sparta.tdd.common.template;
 import com.sparta.tdd.common.config.TestContainerConfig;
 import com.sparta.tdd.common.helper.CleanUp;
 import com.sparta.tdd.global.config.AuditConfig;
+import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({TestContainerConfig.class, CleanUp.class, AuditConfig.class})
+@Import({TestContainerConfig.class, CleanUp.class, AuditConfig.class, QueryDSLConfig.class})
 public abstract class RepositoryTest {
 
     @Autowired
@@ -24,7 +25,7 @@ public abstract class RepositoryTest {
     protected EntityManager em;
 
     @BeforeEach
-    void setUp() {
+    protected void setUp() {
         cleanUp.all();
     }
 }

--- a/src/test/java/com/sparta/tdd/domain/auth/service/AuthServiceUnitTest.java
+++ b/src/test/java/com/sparta/tdd/domain/auth/service/AuthServiceUnitTest.java
@@ -421,7 +421,7 @@ public class AuthServiceUnitTest {
             Cookie refreshCookie = new Cookie("Refresh-Token", refreshToken);
             when(request.getCookies()).thenReturn(new Cookie[]{refreshCookie});
 
-            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_BLACKLISTED))
+            doThrow(new BusinessException(ErrorCode.REFRESH_TOKEN_BLACKLISTED))
                 .when(jwtTokenValidator).validateRefreshToken(refreshToken);
 
             // when & then
@@ -438,7 +438,7 @@ public class AuthServiceUnitTest {
             // given
             when(request.getCookies()).thenReturn(null);
 
-            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_NOT_FOUND))
+            doThrow(new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND))
                 .when(jwtTokenValidator).validateRefreshToken(null);
 
             // when & then
@@ -455,7 +455,7 @@ public class AuthServiceUnitTest {
             Cookie refreshCookie = new Cookie("Refresh-Token", refreshToken);
             when(request.getCookies()).thenReturn(new Cookie[]{refreshCookie});
 
-            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_INVALID))
+            doThrow(new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID))
                 .when(jwtTokenValidator).validateRefreshToken(refreshToken);
 
             // when & then
@@ -472,7 +472,7 @@ public class AuthServiceUnitTest {
             Cookie refreshCookie = new Cookie("Refresh-Token", refreshToken);
             when(request.getCookies()).thenReturn(new Cookie[]{refreshCookie});
 
-            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_INVALID))
+            doThrow(new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID))
                 .when(jwtTokenValidator).validateRefreshToken(refreshToken);
 
             // when & then

--- a/src/test/java/com/sparta/tdd/domain/auth/service/AuthServiceUnitTest.java
+++ b/src/test/java/com/sparta/tdd/domain/auth/service/AuthServiceUnitTest.java
@@ -19,6 +19,8 @@ import com.sparta.tdd.domain.review.repository.ReviewRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import com.sparta.tdd.global.jwt.JwtTokenValidator;
 import com.sparta.tdd.global.jwt.provider.AccessTokenProvider;
 import com.sparta.tdd.global.jwt.provider.RefreshTokenProvider;
@@ -115,8 +117,8 @@ public class AuthServiceUnitTest {
 
             // when
             assertThatThrownBy(() -> authService.signUp(dto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 존재하는 username 입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.NICKNAME_ALREADY_EXISTS.getMessage());
 
             verify(userRepository, never()).save(any(User.class));
         }
@@ -163,8 +165,8 @@ public class AuthServiceUnitTest {
 
             // when & then
             assertThatThrownBy(() -> authService.login(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("올바르지 않은 요청입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -183,8 +185,8 @@ public class AuthServiceUnitTest {
 
             // when & then
             assertThatThrownBy(() -> authService.login(dto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("올바르지 않은 요청입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_LOGIN_CREDENTIALS.getMessage());
         }
     }
 
@@ -213,8 +215,8 @@ public class AuthServiceUnitTest {
 
             // when & then
             assertThatThrownBy(() -> authService.checkUsernameExists(username))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 존재하는 username 입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USERNAME_ALREADY_EXISTS.getMessage());
         }
     }
 
@@ -309,8 +311,8 @@ public class AuthServiceUnitTest {
 
             // when & then
             assertThatThrownBy(() -> authService.withdrawal(userId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 사용자입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
 
             verify(reviewRepository, never()).bulkSoftDeleteByUserId(any(), any(), any());
             verify(withdrawalDataCleanService, never()).deleteOwnerRelatedData(any(), any());
@@ -419,13 +421,13 @@ public class AuthServiceUnitTest {
             Cookie refreshCookie = new Cookie("Refresh-Token", refreshToken);
             when(request.getCookies()).thenReturn(new Cookie[]{refreshCookie});
 
-            doThrow(new IllegalArgumentException("금지된 리프레시 토큰입니다."))
+            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_BLACKLISTED))
                 .when(jwtTokenValidator).validateRefreshToken(refreshToken);
 
             // when & then
             assertThatThrownBy(() -> authService.reissueToken(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("금지된 리프레시 토큰입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_BLACKLISTED.getMessage());
 
             verify(tokenBlacklistService, never()).addRefreshTokenToBlacklist(anyString());
         }
@@ -436,13 +438,13 @@ public class AuthServiceUnitTest {
             // given
             when(request.getCookies()).thenReturn(null);
 
-            doThrow(new IllegalArgumentException("리프레시 토큰이 존재하지 않습니다."))
+            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_NOT_FOUND))
                 .when(jwtTokenValidator).validateRefreshToken(null);
 
             // when & then
             assertThatThrownBy(() -> authService.reissueToken(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("리프레시 토큰이 존재하지 않습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -453,13 +455,13 @@ public class AuthServiceUnitTest {
             Cookie refreshCookie = new Cookie("Refresh-Token", refreshToken);
             when(request.getCookies()).thenReturn(new Cookie[]{refreshCookie});
 
-            doThrow(new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."))
+            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_INVALID))
                 .when(jwtTokenValidator).validateRefreshToken(refreshToken);
 
             // when & then
             assertThatThrownBy(() -> authService.reissueToken(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유효하지 않은 리프레시 토큰입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_INVALID.getMessage());
         }
 
         @Test
@@ -470,13 +472,13 @@ public class AuthServiceUnitTest {
             Cookie refreshCookie = new Cookie("Refresh-Token", refreshToken);
             when(request.getCookies()).thenReturn(new Cookie[]{refreshCookie});
 
-            doThrow(new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."))
+            doThrow(new BusinessException(com.sparta.tdd.global.exception.ErrorCode.REFRESH_TOKEN_INVALID))
                 .when(jwtTokenValidator).validateRefreshToken(refreshToken);
 
             // when & then
             assertThatThrownBy(() -> authService.reissueToken(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유효하지 않은 리프레시 토큰입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.REFRESH_TOKEN_INVALID.getMessage());
         }
 
         @Test
@@ -496,8 +498,8 @@ public class AuthServiceUnitTest {
 
             // when & then
             assertThatThrownBy(() -> authService.reissueToken(request))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("올바르지 않은 요청입니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
@@ -11,6 +11,7 @@ import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.global.config.AuditConfig;
+import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ import org.springframework.context.annotation.Import;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(AuditConfig.class)
+@Import({AuditConfig.class, QueryDSLConfig.class})
 class OrderMenuRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/sparta/tdd/domain/review/repository/ReviewReplyRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/review/repository/ReviewReplyRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.sparta.tdd.domain.review.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sparta.tdd.common.template.RepositoryTest;
 import com.sparta.tdd.domain.order.entity.Order;
 import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.order.repository.OrderRepository;
@@ -11,27 +14,17 @@ import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@DataJpaTest
 @DisplayName("ReviewReplyRepository 테스트")
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@EnableJpaAuditing
-class ReviewReplyRepositoryTest {
+class ReviewReplyRepositoryTest extends RepositoryTest {
 
     @Autowired
     private ReviewReplyRepository reviewReplyRepository;
@@ -51,61 +44,63 @@ class ReviewReplyRepositoryTest {
     private Review testReview;
     private ReviewReply testReply;
 
+    @Override
     @BeforeEach
-    void 초기세팅() {
+    protected void setUp() {
+        super.setUp();
         // 고객 사용자 생성
         customer = User.builder()
-                .username("customer")
-                .password("password123")
-                .nickname("고객")
-                .authority(UserAuthority.CUSTOMER)
-                .build();
+            .username("customer")
+            .password("password123")
+            .nickname("고객")
+            .authority(UserAuthority.CUSTOMER)
+            .build();
         customer = userRepository.save(customer);
 
         // 가게 사장 사용자 생성
         owner = User.builder()
-                .username("owner")
-                .password("password123")
-                .nickname("사장님")
-                .authority(UserAuthority.OWNER)
-                .build();
+            .username("owner")
+            .password("password123")
+            .nickname("사장님")
+            .authority(UserAuthority.OWNER)
+            .build();
         owner = userRepository.save(owner);
 
         // 테스트용 가게 생성
         testStore = Store.builder()
-                .name("테스트 가게")
-                .category(StoreCategory.KOREAN)
-                .description("맛있는 한식당")
-                .user(owner)
-                .build();
+            .name("테스트 가게")
+            .category(StoreCategory.KOREAN)
+            .description("맛있는 한식당")
+            .user(owner)
+            .build();
         testStore = storeRepository.save(testStore);
 
         // 테스트용 주문 생성
         testOrder = Order.builder()
-                .address("서울시 강남구")
-                .orderStatus(OrderStatus.DELIVERED)
-                .store(testStore)
-                .user(customer)
-                .build();
+            .address("서울시 강남구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(customer)
+            .build();
         testOrder = orderRepository.save(testOrder);
 
         // 테스트용 리뷰 생성
         testReview = Review.builder()
-                .user(customer)
-                .store(testStore)
-                .order(testOrder)
-                .rating(5)
-                .imageUrl("http://example.com/image.jpg")
-                .content("정말 맛있어요!")
-                .build();
+            .user(customer)
+            .store(testStore)
+            .order(testOrder)
+            .rating(5)
+            .imageUrl("http://example.com/image.jpg")
+            .content("정말 맛있어요!")
+            .build();
         testReview = reviewRepository.save(testReview);
 
         // 테스트용 답글 생성
         testReply = ReviewReply.builder()
-                .review(testReview)
-                .content("감사합니다!")
-                .ownerId(owner.getId())
-                .build();
+            .review(testReview)
+            .content("감사합니다!")
+            .ownerId(owner.getId())
+            .build();
         testReply = reviewReplyRepository.save(testReply);
     }
 
@@ -140,13 +135,21 @@ class ReviewReplyRepositoryTest {
     @DisplayName("답글이 없는 리뷰 조회")
     void 노답글조회() {
         // given
+        Order newOrder = Order.builder()
+            .address("서울시 서초구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(customer)
+            .build();
+        newOrder = orderRepository.save(newOrder);
+
         Review newReview = Review.builder()
-                .user(customer)
-                .store(testStore)
-                .order(testOrder)
-                .rating(4)
-                .content("두 번째 리뷰")
-                .build();
+            .user(customer)
+            .store(testStore)
+            .order(newOrder)
+            .rating(4)
+            .content("두 번째 리뷰")
+            .build();
         newReview = reviewRepository.save(newReview);
 
         // when
@@ -160,42 +163,58 @@ class ReviewReplyRepositoryTest {
     @DisplayName("여러 리뷰의 삭제되지 않은 답글 목록 조회")
     void 리뷰목록조회() {
         // given
+        Order order2 = Order.builder()
+            .address("서울시 송파구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(customer)
+            .build();
+        order2 = orderRepository.save(order2);
+
         Review review2 = Review.builder()
-                .user(customer)
-                .store(testStore)
-                .order(testOrder)
-                .rating(4)
-                .content("두 번째 리뷰")
-                .build();
+            .user(customer)
+            .store(testStore)
+            .order(order2)
+            .rating(4)
+            .content("두 번째 리뷰")
+            .build();
         review2 = reviewRepository.save(review2);
 
         ReviewReply reply2 = ReviewReply.builder()
-                .review(review2)
-                .content("감사합니다! 또 방문해주세요!")
-                .ownerId(owner.getId())
-                .build();
+            .review(review2)
+            .content("감사합니다! 또 방문해주세요!")
+            .ownerId(owner.getId())
+            .build();
         reply2 = reviewReplyRepository.save(reply2);
 
+        Order order3 = Order.builder()
+            .address("서울시 관악구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(customer)
+            .build();
+        order3 = orderRepository.save(order3);
+
         Review review3 = Review.builder()
-                .user(customer)
-                .store(testStore)
-                .order(testOrder)
-                .rating(3)
-                .content("세 번째 리뷰")
-                .build();
+            .user(customer)
+            .store(testStore)
+            .order(order3)
+            .rating(3)
+            .content("세 번째 리뷰")
+            .build();
         review3 = reviewRepository.save(review3);
 
         ReviewReply reply3 = ReviewReply.builder()
-                .review(review3)
-                .content("방문 감사합니다")
-                .ownerId(owner.getId())
-                .build();
+            .review(review3)
+            .content("방문 감사합니다")
+            .ownerId(owner.getId())
+            .build();
         reply3 = reviewReplyRepository.save(reply3);
 
         List<UUID> reviewIds = Arrays.asList(
-                testReview.getId(),
-                review2.getId(),
-                review3.getId()
+            testReview.getId(),
+            review2.getId(),
+            review3.getId()
         );
 
         // when
@@ -204,7 +223,7 @@ class ReviewReplyRepositoryTest {
         // then
         assertThat(result).hasSize(3);
         assertThat(result).extracting(ReviewReply::getReviewId)
-                .containsExactlyInAnyOrder(testReview.getId(), review2.getId(), review3.getId());
+            .containsExactlyInAnyOrder(testReview.getId(), review2.getId(), review3.getId());
     }
 
 
@@ -225,20 +244,28 @@ class ReviewReplyRepositoryTest {
     @DisplayName("답글 저장 및 리뷰 연관관계 확인")
     void 진짜제대로된건가() {
         // given
+        Order newOrder = Order.builder()
+            .address("서울시 마포구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(customer)
+            .build();
+        newOrder = orderRepository.save(newOrder);
+
         Review newReview = Review.builder()
-                .user(customer)
-                .store(testStore)
-                .order(testOrder)
-                .rating(5)
-                .content("새로운 리뷰")
-                .build();
+            .user(customer)
+            .store(testStore)
+            .order(newOrder)
+            .rating(5)
+            .content("새로운 리뷰")
+            .build();
         newReview = reviewRepository.save(newReview);
 
         ReviewReply newReply = ReviewReply.builder()
-                .review(newReview)
-                .content("감사합니다!")
-                .ownerId(owner.getId())
-                .build();
+            .review(newReview)
+            .content("감사합니다!")
+            .ownerId(owner.getId())
+            .build();
 
         // when
         ReviewReply savedReply = reviewReplyRepository.save(newReply);

--- a/src/test/java/com/sparta/tdd/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/review/repository/ReviewRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.sparta.tdd.domain.review.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sparta.tdd.common.template.RepositoryTest;
 import com.sparta.tdd.domain.order.entity.Order;
 import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.order.repository.OrderRepository;
@@ -10,28 +13,19 @@ import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@DataJpaTest
 @DisplayName("ReviewRepository 테스트")
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@EnableJpaAuditing
-class ReviewRepositoryTest {
+class ReviewRepositoryTest extends RepositoryTest {
 
     @Autowired
     private ReviewRepository reviewRepository;
@@ -51,40 +45,40 @@ class ReviewRepositoryTest {
     void 필요세팅() {
         // 테스트용 사용자 생성
         testUser = User.builder()
-                .username("testuser")
-                .password("password123")
-                .nickname("테스트유저")
-                .authority(UserAuthority.CUSTOMER)
-                .build();
+            .username("testuser")
+            .password("password123")
+            .nickname("테스트유저")
+            .authority(UserAuthority.CUSTOMER)
+            .build();
         testUser = userRepository.save(testUser);
 
         // 테스트용 가게 생성
         testStore = Store.builder()
-                .name("테스트 가게")
-                .category(StoreCategory.KOREAN)
-                .description("맛있는 한식당")
-                .user(testUser)
-                .build();
+            .name("테스트 가게")
+            .category(StoreCategory.KOREAN)
+            .description("맛있는 한식당")
+            .user(testUser)
+            .build();
         testStore = storeRepository.save(testStore);
 
         // 테스트용 주문 생성
         testOrder = Order.builder()
-                .address("서울시 강남구")
-                .orderStatus(OrderStatus.DELIVERED)
-                .store(testStore)
-                .user(testUser)
-                .build();
+            .address("서울시 강남구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(testUser)
+            .build();
         testOrder = orderRepository.save(testOrder);
 
         // 테스트용 리뷰 생성
         testReview = Review.builder()
-                .user(testUser)
-                .store(testStore)
-                .order(testOrder)
-                .rating(5)
-                .imageUrl("http://example.com/image.jpg")
-                .content("정말 맛있어요!")
-                .build();
+            .user(testUser)
+            .store(testStore)
+            .order(testOrder)
+            .rating(5)
+            .imageUrl("http://example.com/image.jpg")
+            .content("정말 맛있어요!")
+            .build();
         testReview = reviewRepository.save(testReview);
     }
 
@@ -119,13 +113,21 @@ class ReviewRepositoryTest {
     @DisplayName("특정 유저의 삭제되지 않은 리뷰 목록 조회")
     void 리뷰조회() {
         // given
+        Order order2 = Order.builder()
+            .address("서울시 서초구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(testUser)
+            .build();
+        order2 = orderRepository.save(order2);
+
         Review review2 = Review.builder()
-                .user(testUser)
-                .store(testStore)
-                .order(testOrder)
-                .rating(4)
-                .content("두 번째 리뷰")
-                .build();
+            .user(testUser)
+            .store(testStore)
+            .order(order2)
+            .rating(4)
+            .content("두 번째 리뷰")
+            .build();
         reviewRepository.save(review2);
 
         // when
@@ -134,20 +136,28 @@ class ReviewRepositoryTest {
         // then
         assertThat(result).hasSize(2);
         assertThat(result).extracting(Review::getUserId)
-                .containsOnly(testUser.getId());
+            .containsOnly(testUser.getId());
     }
 
     @Test
     @DisplayName("특정 가게의 삭제되지 않은 리뷰 목록 조회")
     void 리뷰목록조회() {
         // given
+        Order order2 = Order.builder()
+            .address("서울시 송파구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(testUser)
+            .build();
+        order2 = orderRepository.save(order2);
+
         Review review2 = Review.builder()
-                .user(testUser)
-                .store(testStore)
-                .order(testOrder)
-                .rating(3)
-                .content("보통이에요")
-                .build();
+            .user(testUser)
+            .store(testStore)
+            .order(order2)
+            .rating(3)
+            .content("보통이에요")
+            .build();
         reviewRepository.save(review2);
 
         // when
@@ -156,7 +166,7 @@ class ReviewRepositoryTest {
         // then
         assertThat(result).hasSize(2);
         assertThat(result).extracting(Review::getStoreId)
-                .containsOnly(testStore.getId());
+            .containsOnly(testStore.getId());
     }
 
     @Test
@@ -164,13 +174,21 @@ class ReviewRepositoryTest {
     void 리뷰페이징() {
         // given
         for (int i = 0; i < 15; i++) {
+            Order order = Order.builder()
+                .address("서울시 관악구 " + i)
+                .orderStatus(OrderStatus.DELIVERED)
+                .store(testStore)
+                .user(testUser)
+                .build();
+            order = orderRepository.save(order);
+
             Review review = Review.builder()
-                    .user(testUser)
-                    .store(testStore)
-                    .order(testOrder)
-                    .rating(4)
-                    .content("리뷰 " + i)
-                    .build();
+                .user(testUser)
+                .store(testStore)
+                .order(order)
+                .rating(4)
+                .content("리뷰 " + i)
+                .build();
             reviewRepository.save(review);
         }
 
@@ -189,13 +207,21 @@ class ReviewRepositoryTest {
     @DisplayName("특정 가게의 평균 평점 조회")
     void 평균조회() {
         // given
+        Order order2 = Order.builder()
+            .address("서울시 마포구")
+            .orderStatus(OrderStatus.DELIVERED)
+            .store(testStore)
+            .user(testUser)
+            .build();
+        order2 = orderRepository.save(order2);
+
         Review review2 = Review.builder()
-                .user(testUser)
-                .store(testStore)
-                .order(testOrder)
-                .rating(3)
-                .content("보통이에요")
-                .build();
+            .user(testUser)
+            .store(testStore)
+            .order(order2)
+            .rating(3)
+            .content("보통이에요")
+            .build();
         reviewRepository.save(review2);
 
         // when
@@ -210,10 +236,10 @@ class ReviewRepositoryTest {
     void 빵점조회() {
         // given
         Store newStore = Store.builder()
-                .name("새로운 가게")
-                .category(StoreCategory.CHINESE)
-                .user(testUser)
-                .build();
+            .name("새로운 가게")
+            .category(StoreCategory.CHINESE)
+            .user(testUser)
+            .build();
         newStore = storeRepository.save(newStore);
 
         // when

--- a/src/test/java/com/sparta/tdd/domain/review/service/ReviewReplyServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/review/service/ReviewReplyServiceTest.java
@@ -14,6 +14,8 @@ import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -180,8 +182,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.createReply(reviewId, owner.getId(), requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 리뷰입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_NOT_FOUND.getMessage());
 
             verify(reviewReplyRepository, never()).save(any());
         }
@@ -199,8 +201,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.createReply(reviewId, owner.getId(), requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("이미 답글이 존재합니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_ALREADY_EXISTS.getMessage());
 
             verify(reviewReplyRepository, never()).save(any());
         }
@@ -224,8 +226,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.createReply(reviewId, 3L, requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED.getMessage());
 
             verify(reviewReplyRepository, never()).save(any());
         }
@@ -241,8 +243,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.createReply(reviewId, owner.getId(), requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 가게입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.STORE_NOT_FOUND.getMessage());
 
             verify(reviewReplyRepository, never()).save(any());
         }
@@ -259,8 +261,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.createReply(reviewId, owner.getId(), requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 사용자입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
 
             verify(reviewReplyRepository, never()).save(any());
         }
@@ -302,8 +304,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.updateReply(reviewId, owner.getId(), requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 답글입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -325,8 +327,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.updateReply(reviewId, 3L, requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED.getMessage());
         }
     }
 
@@ -359,8 +361,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.deleteReply(reviewId, owner.getId()))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 답글입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -381,8 +383,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.deleteReply(reviewId, 3L))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED.getMessage());
         }
     }
 
@@ -466,8 +468,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.updateReply(reviewId, 3L, requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED.getMessage());
         }
 
         @Test
@@ -505,8 +507,8 @@ class ReviewReplyServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewReplyService.createReply(reviewId, customer.getId(), requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("해당 가게의 소유자만 답글을 작성할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_REPLY_PERMISSION_DENIED.getMessage());
 
             verify(reviewReplyRepository, never()).save(any());
         }

--- a/src/test/java/com/sparta/tdd/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/review/service/ReviewServiceTest.java
@@ -16,6 +16,8 @@ import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
+import com.sparta.tdd.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -183,8 +185,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.createReview(userId, orderId, requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 사용자입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
 
             verify(userRepository).findById(userId);
             verify(reviewRepository, never()).save(any());
@@ -206,8 +208,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.createReview(userId, orderId, requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 가게입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.STORE_NOT_FOUND.getMessage());
 
             verify(reviewRepository, never()).save(any());
         }
@@ -229,8 +231,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.createReview(userId, orderId, requestDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 주문입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 
             verify(reviewRepository, never()).save(any());
         }
@@ -274,8 +276,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.updateReview(reviewId, userId, updateDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 리뷰입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -293,8 +295,8 @@ class ReviewServiceTest {
             Long anotherUserId = userId + 3;
             // when & then
             assertThatThrownBy(() -> reviewService.updateReview(reviewId, anotherUserId, updateDto))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("본인의 리뷰만 수정할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_NOT_OWNED.getMessage());
         }
     }
 
@@ -351,8 +353,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.getReview(reviewId))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 리뷰입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_NOT_FOUND.getMessage());
         }
     }
 
@@ -439,8 +441,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.deleteReview(reviewId, userId))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("존재하지 않는 리뷰입니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -451,8 +453,8 @@ class ReviewServiceTest {
 
             // when & then
             assertThatThrownBy(() -> reviewService.deleteReview(reviewId, 999L))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("본인의 리뷰만 삭제할 수 있습니다.");
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.REVIEW_NOT_OWNED.getMessage());
         }
     }
 }

--- a/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryTest.java
@@ -8,6 +8,7 @@ import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.global.config.AuditConfig;
+import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.List;
@@ -21,7 +22,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(AuditConfig.class)
+@Import({AuditConfig.class, QueryDSLConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class StoreRepositoryTest {
 

--- a/src/test/java/com/sparta/tdd/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/user/repository/UserRepositoryTest.java
@@ -1,21 +1,23 @@
 package com.sparta.tdd.domain.user.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
+import com.sparta.tdd.global.config.AuditConfig;
+import com.sparta.tdd.global.config.QueryDSLConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("local")
+@Import({AuditConfig.class, QueryDSLConfig.class})
 class UserRepositoryTest {
 
     private User user;
@@ -25,12 +27,13 @@ class UserRepositoryTest {
     @BeforeEach
     void init() {
         user = User.builder()
-                .username("test01")
-                .password("test12345")
-                .nickname("test")
-                .authority(UserAuthority.CUSTOMER)
-                .build();
+            .username("test01")
+            .password("test12345")
+            .nickname("test")
+            .authority(UserAuthority.CUSTOMER)
+            .build();
     }
+
     @Test
     void signup() {
         //when
@@ -39,6 +42,7 @@ class UserRepositoryTest {
         //then
         assertEquals(true, userRepository.existsByUsername("test01"));
     }
+
     @Test
     void readUserProfile() {
         //given
@@ -52,6 +56,7 @@ class UserRepositoryTest {
         assertEquals(user.getUsername(), findUser.getUsername());
         assertEquals(UserAuthority.CUSTOMER, findUser.getAuthority());
     }
+
     @Test
     void updateUserProfile() {
         //given
@@ -68,6 +73,7 @@ class UserRepositoryTest {
         assertEquals(findUser.getNickname(), updatedUser.getNickname());
         assertEquals(findUser.getAuthority(), updatedUser.getAuthority());
     }
+
     @Test
     void deleteUser() {
         //given

--- a/src/test/java/com/sparta/tdd/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.sparta.tdd.domain.user.dto.UserResponseDto;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
+import com.sparta.tdd.global.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,7 +94,7 @@ class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // then
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(BusinessException.class, () -> {
             // when
             userService.grantUserManagerAuthority(1L);
         });
@@ -105,7 +106,7 @@ class UserServiceTest {
         User user = createUser("test01", "1234", "test1", UserAuthority.CUSTOMER);
 
         // then
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(BusinessException.class, () -> {
             // when
             userService.grantUserManagerAuthority(1L);
         });
@@ -133,7 +134,7 @@ class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user1));
 
         //then
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(BusinessException.class, () -> {
             //when
             userService.updateUserNickname(1L, 1L, requestDto);
         });


### PR DESCRIPTION
## PR 내용

- [feat(common): 공통 예외 처리를 위한 에러코드 및 Exception 추가](https://github.com/Sparta-21/TDD/commit/e5ca46b1c49f864c4123d5319ef18cdf982f1c2d)
  - 기존 IlliegalArgumentException, EntityNotFoundException 등 비즈니스 로직에서 표준 예외를 사용하던 부분을 하나의 공통된 예외로 변경했습니다.
  - ErrorCode enum을 통해, 하나의 파일에서 에러코드를 관리해 불필요한 중복을 줄이고자 했습니다.
  - 코드별로 HTTP 상태 코드와 추가적인 에러 메시지를 정의할 수 있도록 설정했습니다.

- [test(common): 공통 예외처리 적용으로 인한 테스트 코드 리팩토링 진행](https://github.com/Sparta-21/TDD/commit/c772a76460c6a8da4a5d8719f62c216295d9ae37)
  - 비즈니스 로직의 에러 처리의 변경에 따라 테스트 케이스의 통과 조건도 변경하게 되었습니다.
  - hasMessage() 부분에서 하드코딩 된 메시지 대신, getMessage()를 통해 에러 문구 변경에도 안정성을 확보했습니다.

## 추가 내용
- 기존의 테스트 코드들에서 코드의 추가 및 기능 개발에 따라, 불통과 되는 케이스가 존재해 이를 수정했습니다. 각 담당하시는 분들께서는 변경된 테스트 내용을 한번씩 확인해주시면 감사하겠습니다.