### PR TITLE
chore(ci): CI 파이프라인 작성

### DIFF
--- a/.github/workflows/integration_workflow.yml
+++ b/.github/workflows/integration_workflow.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run test
+      - name: Run build
         env:
           SPRING_PROFILES_ACTIVE: test
         run: ./gradlew build

--- a/.github/workflows/integration_workflow.yml
+++ b/.github/workflows/integration_workflow.yml
@@ -1,0 +1,43 @@
+name: TDD Project Integration Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  Test-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/build-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run test
+        env:
+          SPRING_PROFILES_ACTIVE: test
+        run: ./gradlew build

--- a/.github/workflows/integration_workflow.yml
+++ b/.github/workflows/integration_workflow.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Run build
         env:
           SPRING_PROFILES_ACTIVE: test
-        run: ./gradlew build
+        run: ./gradlew build > /dev/null 2>&1

--- a/src/main/java/com/sparta/tdd/domain/ai/config/GenerateContentWithConfigs.java
+++ b/src/main/java/com/sparta/tdd/domain/ai/config/GenerateContentWithConfigs.java
@@ -2,7 +2,15 @@ package com.sparta.tdd.domain.ai.config;
 
 import autovalue.shaded.com.google.common.collect.ImmutableList;
 import com.google.genai.Client;
-import com.google.genai.types.*;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GoogleSearch;
+import com.google.genai.types.HarmBlockThreshold;
+import com.google.genai.types.HarmCategory;
+import com.google.genai.types.Part;
+import com.google.genai.types.SafetySetting;
+import com.google.genai.types.ThinkingConfig;
+import com.google.genai.types.Tool;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,38 +18,40 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class GenerateContentWithConfigs {
 
-    @Value("${GOOGLE_API_KEY}")
+    @Value("${ai.google.api-key}")
     private String apiKey;
+
     @Bean
     public Client client() {
         return Client.builder().apiKey(apiKey).build();
     }
+
     @Bean
     public GenerateContentConfig generateContentConfig() {
         ImmutableList<SafetySetting> safetySettings =
-                ImmutableList.of(
-                        SafetySetting.builder()
-                                .category(HarmCategory.Known.HARM_CATEGORY_HATE_SPEECH)
-                                .threshold(HarmBlockThreshold.Known.BLOCK_ONLY_HIGH)
-                                .build(),
-                        SafetySetting.builder()
-                                .category(HarmCategory.Known.HARM_CATEGORY_DANGEROUS_CONTENT)
-                                .threshold(HarmBlockThreshold.Known.BLOCK_LOW_AND_ABOVE)
-                                .build());
+            ImmutableList.of(
+                SafetySetting.builder()
+                    .category(HarmCategory.Known.HARM_CATEGORY_HATE_SPEECH)
+                    .threshold(HarmBlockThreshold.Known.BLOCK_ONLY_HIGH)
+                    .build(),
+                SafetySetting.builder()
+                    .category(HarmCategory.Known.HARM_CATEGORY_DANGEROUS_CONTENT)
+                    .threshold(HarmBlockThreshold.Known.BLOCK_LOW_AND_ABOVE)
+                    .build());
 
         Content systemInstruction = Content.fromParts(
-                Part.fromText(
-                        "{사용자 입력}을 바탕으로 음식점에서 손님의 이목을 끌만한 20자 이하의 짧은 소개글을 만들어주세요. 문장은 한 줄로 작성합니다."));
+            Part.fromText(
+                "{사용자 입력}을 바탕으로 음식점에서 손님의 이목을 끌만한 20자 이하의 짧은 소개글을 만들어주세요. 문장은 한 줄로 작성합니다."));
 
         Tool googleSearchTool = Tool.builder().googleSearch(GoogleSearch.builder()).build();
 
         return GenerateContentConfig.builder()
-                        .thinkingConfig(ThinkingConfig.builder().thinkingBudget(0))
-                        .candidateCount(1)
-                        .maxOutputTokens(1024)
-                        .safetySettings(safetySettings)
-                        .systemInstruction(systemInstruction)
-                        .tools(googleSearchTool)
-                        .build();
+            .thinkingConfig(ThinkingConfig.builder().thinkingBudget(0))
+            .candidateCount(1)
+            .maxOutputTokens(1024)
+            .safetySettings(safetySettings)
+            .systemInstruction(systemInstruction)
+            .tools(googleSearchTool)
+            .build();
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
@@ -15,7 +15,7 @@ public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositor
 
     List<Menu> findAllByStoreId(UUID storeId);
 
-    Optional<Menu> findByStoreIdAndMenuIdAndIsDeletedFalse(UUID storeId, UUID menuId);
+    Optional<Menu> findByIdAndStoreIdAndIsDeletedFalse(UUID menuId, UUID storeId);
 
     List<Menu> findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(UUID storeId);
 

--- a/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
@@ -88,7 +88,7 @@ public class MenuService {
     }
 
     private Menu findMenu(UUID storeId, UUID menuId) {
-        return menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(storeId, menuId)
+        return menuRepository.findByIdAndStoreIdAndIsDeletedFalse(menuId, storeId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다."));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,18 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+logging:
+  level:
+    root: WARN
+    org.springframework: WARN
+    org.hibernate: WARN
+    org.hibernate.SQL: OFF
+    org.hibernate.type.descriptor.sql.BasicBinder: OFF
 
 jwt:
   access:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,7 @@ logging:
     org.hibernate: WARN
     org.hibernate.SQL: OFF
     org.hibernate.type.descriptor.sql.BasicBinder: OFF
+    org.hibernate.tool.hbm2ddl: OFF
 
 jwt:
   access:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ jwt:
     secret: ${JWT_REFRESH_SECRET}
     expiration: ${JWT_REFRESH_EXPIRED}
 
+ai:
+  google:
+    api-key: ${GOOGLE_API_KEY}
+
 ---
 spring:
   config:
@@ -83,3 +87,7 @@ jwt:
   refresh:
     secret: testRefreshSecrettestRefreshSecret
     expiration: 2000
+
+ai:
+  google:
+    api-key: testApiKey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,15 +84,6 @@ spring:
       hibernate:
         format_sql: false
 
-logging:
-  level:
-    root: WARN
-    org.springframework: WARN
-    org.hibernate: WARN
-    org.hibernate.SQL: OFF
-    org.hibernate.type.descriptor.sql.BasicBinder: OFF
-    org.hibernate.tool.hbm2ddl: OFF
-
 jwt:
   access:
     secret: testAccessSecrettestAccessSecret

--- a/src/test/java/com/sparta/tdd/common/helper/CleanUp.java
+++ b/src/test/java/com/sparta/tdd/common/helper/CleanUp.java
@@ -21,7 +21,7 @@ public class CleanUp {
     }
 
     @Transactional
-    public void all() {
+    public void tearDown() {
         Set<String> tables = entityManager.getMetamodel().getEntities().stream()
             .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
             .map(entity -> {

--- a/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/IntegrationTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.tdd.common.config.TestContainerConfig;
 import com.sparta.tdd.common.helper.CleanUp;
 import com.sparta.tdd.global.config.QueryDSLConfig;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,8 +27,8 @@ public abstract class IntegrationTest {
     @Autowired
     protected CleanUp cleanUp;
 
-    @BeforeEach
-    protected void setUp() {
-        cleanUp.all();
+    @AfterEach
+    protected void tearDown() {
+        cleanUp.tearDown();
     }
 }

--- a/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/common/template/RepositoryTest.java
@@ -5,7 +5,7 @@ import com.sparta.tdd.common.helper.CleanUp;
 import com.sparta.tdd.global.config.AuditConfig;
 import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -24,8 +24,8 @@ public abstract class RepositoryTest {
     @Autowired
     protected EntityManager em;
 
-    @BeforeEach
-    protected void setUp() {
-        cleanUp.all();
+    @AfterEach
+    protected void tearDown() {
+        cleanUp.tearDown();
     }
 }

--- a/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
@@ -45,7 +45,7 @@ public class MenuIntegrationTest extends IntegrationTest {
     Menu menu;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         customer = User.builder()
             .username("customer")
             .password("password1")

--- a/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
@@ -44,10 +44,8 @@ public class MenuIntegrationTest extends IntegrationTest {
     Store store;
     Menu menu;
 
-    @Override
     @BeforeEach
     public void setUp() {
-        super.cleanUp.all();
         customer = User.builder()
             .username("customer")
             .password("password1")

--- a/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
@@ -166,24 +166,21 @@ public class MenuServiceTest {
         @DisplayName("Customer 메뉴 상세 테스트")
         void getMenusCustomerTest() {
             //given
-            when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-                menu2.getId()))
+            when(menuRepository.findByIdAndStoreIdAndIsDeletedFalse(menu2.getId(), store.getId()))
                 .thenReturn(Optional.of(menu2));
 
             // when & then
             assertThrows(IllegalArgumentException.class,
                 () -> menuService.getMenu(store.getId(), menu2.getId(),
                     customer.getAuthority()));
-            verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-                menu2.getId());
+            verify(menuRepository, times(1)).findByIdAndStoreIdAndIsDeletedFalse(menu2.getId(), store.getId());
         }
 
         @Test
         @DisplayName("OWNER 메뉴 상세 테스트")
         void getMenusOwnerTest() {
             //given
-            when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-                menu2.getId()))
+            when(menuRepository.findByIdAndStoreIdAndIsDeletedFalse(menu2.getId(), store.getId()))
                 .thenReturn(Optional.of(menu2));
 
             // when
@@ -193,8 +190,7 @@ public class MenuServiceTest {
             // then
             assertNotNull(testMenu);
             assertEquals(menu2.getId(), testMenu.menuId());
-            verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-                menu2.getId());
+            verify(menuRepository, times(1)).findByIdAndStoreIdAndIsDeletedFalse(menu2.getId(), store.getId());
         }
 
     }
@@ -226,7 +222,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 수정 테스트")
     void updateMenuSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(), menu1.getId()))
+        when(menuRepository.findByIdAndStoreIdAndIsDeletedFalse(menu1.getId(), store.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -235,8 +231,7 @@ public class MenuServiceTest {
         menuService.updateMenu(store.getId(), menu1.getId(), dto3, 2L);
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-            menu1.getId());
+        verify(menuRepository, times(1)).findByIdAndStoreIdAndIsDeletedFalse(menu1.getId(), store.getId());
         assertEquals(dto3.name(), menu1.getName());
         assertEquals(dto3.description(), menu1.getDescription());
         assertEquals(dto3.price(), menu1.getPrice());
@@ -248,7 +243,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 상태 수정 테스트")
     void updateMenuStatusSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(), menu1.getId()))
+        when(menuRepository.findByIdAndStoreIdAndIsDeletedFalse(menu1.getId(), store.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -257,8 +252,7 @@ public class MenuServiceTest {
         menuService.updateMenuStatus(store.getId(), menu1.getId(), Boolean.TRUE, 2L);
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-            menu1.getId());
+        verify(menuRepository, times(1)).findByIdAndStoreIdAndIsDeletedFalse(menu1.getId(), store.getId());
         assertTrue(menu1.isHidden());
     }
 
@@ -266,7 +260,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 삭제 테스트(soft delete)")
     void deleteMenuSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(), menu1.getId()))
+        when(menuRepository.findByIdAndStoreIdAndIsDeletedFalse(menu1.getId(), store.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -275,8 +269,7 @@ public class MenuServiceTest {
         menuService.deleteMenu(store.getId(), menu1.getId(), owner.getId());
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
-            menu1.getId());
+        verify(menuRepository, times(1)).findByIdAndStoreIdAndIsDeletedFalse(menu1.getId(), store.getId());
         assertNotNull(menu1.getDeletedAt());
         assertEquals(owner.getId(), menu1.getDeletedBy());
     }

--- a/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/order/repository/OrderRepositoryTest.java
@@ -5,6 +5,7 @@ import static com.sparta.tdd.domain.user.enums.UserAuthority.CUSTOMER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.tdd.common.template.RepositoryTest;
 import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
 import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.order.entity.Order;
@@ -12,8 +13,6 @@ import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.orderMenu.entity.OrderMenu;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.user.entity.User;
-import com.sparta.tdd.global.config.AuditConfig;
-import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceUnitUtil;
 import java.util.ArrayList;
@@ -23,14 +22,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({AuditConfig.class, QueryDSLConfig.class})
-class OrderRepositoryTest {
+class OrderRepositoryTest extends RepositoryTest {
 
     @Autowired
     private OrderRepository orderRepository;
@@ -46,6 +39,7 @@ class OrderRepositoryTest {
         @DisplayName("ID 로 주문 조회")
         void findId() {
             Order order = Order.builder()
+                .address("서울시 강남구 테스트동 123")
                 .build();
             Order saved = orderRepository.save(order);
 
@@ -59,6 +53,7 @@ class OrderRepositoryTest {
         @DisplayName("Dirty Checking 확인")
         void update() {
             Order order = Order.builder()
+                .address("서울시 강남구 테스트동 123")
                 .build();
             Order saved = orderRepository.save(order);
 
@@ -74,6 +69,7 @@ class OrderRepositoryTest {
         @DisplayName("Id 로 삭제상태 변경 확인")
         void delete() {
             Order order = Order.builder()
+                .address("서울시 강남구 테스트동 123")
                 .build();
             Order saved = orderRepository.save(order);
 
@@ -173,7 +169,6 @@ class OrderRepositoryTest {
                     ", qty=" + om.getQuantity()
             );
         }
-
 
         // 연관 로딩 검증
         assertThat(util.isLoaded(found.getUser())).isTrue();

--- a/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sparta.tdd.domain.orderMenu.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sparta.tdd.common.template.RepositoryTest;
 import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
 import com.sparta.tdd.domain.menu.entity.Menu;
 import com.sparta.tdd.domain.order.entity.Order;
@@ -10,8 +11,6 @@ import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
-import com.sparta.tdd.global.config.AuditConfig;
-import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,14 +18,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({AuditConfig.class, QueryDSLConfig.class})
-class OrderMenuRepositoryTest {
+class OrderMenuRepositoryTest extends RepositoryTest {
 
     @Autowired
     private OrderMenuRepository orderMenuRepository;
@@ -40,7 +33,7 @@ class OrderMenuRepositoryTest {
     private Menu testMenu;
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         testUser = User.builder()
             .username("testuser")
             .password("password123")
@@ -58,6 +51,7 @@ class OrderMenuRepositoryTest {
         em.persist(testStore);
 
         testOrder = Order.builder()
+            .address("서울시 강남구 테스트동 123")
             .user(testUser)
             .store(testStore)
             .build();

--- a/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/orderMenu/repository/OrderMenuRepositoryTest.java
@@ -33,7 +33,7 @@ class OrderMenuRepositoryTest extends RepositoryTest {
     private Menu testMenu;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         testUser = User.builder()
             .username("testuser")
             .password("password123")

--- a/src/test/java/com/sparta/tdd/domain/review/repository/ReviewReplyRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/review/repository/ReviewReplyRepositoryTest.java
@@ -44,10 +44,8 @@ class ReviewReplyRepositoryTest extends RepositoryTest {
     private Review testReview;
     private ReviewReply testReply;
 
-    @Override
     @BeforeEach
     protected void setUp() {
-        super.setUp();
         // 고객 사용자 생성
         customer = User.builder()
             .username("customer")

--- a/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImplTest.java
+++ b/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImplTest.java
@@ -11,7 +11,6 @@ import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
-import com.sparta.tdd.global.config.QueryDSLConfig;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.List;
@@ -21,12 +20,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
-
-@Import(QueryDSLConfig.class)
 
 @DisplayName("StoreRepositoryImpl 커스텀 쿼리 테스트")
 class StoreRepositoryImplTest extends RepositoryTest {
@@ -41,7 +37,7 @@ class StoreRepositoryImplTest extends RepositoryTest {
     private Pageable pageable;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         testUser = User.builder()
             .username("testuser")
             .password("password123")

--- a/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImplTest.java
+++ b/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryImplTest.java
@@ -41,7 +41,7 @@ class StoreRepositoryImplTest extends RepositoryTest {
     private Pageable pageable;
 
     @BeforeEach
-    void setUp() throws Exception {
+    public void setUp() {
         testUser = User.builder()
             .username("testuser")
             .password("password123")

--- a/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/store/repository/StoreRepositoryTest.java
@@ -3,12 +3,11 @@ package com.sparta.tdd.domain.store.repository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sparta.tdd.common.template.RepositoryTest;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.enums.StoreCategory;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
-import com.sparta.tdd.global.config.AuditConfig;
-import com.sparta.tdd.global.config.QueryDSLConfig;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.List;
@@ -17,14 +16,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
-@DataJpaTest
-@Import({AuditConfig.class, QueryDSLConfig.class})
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class StoreRepositoryTest {
+class StoreRepositoryTest extends RepositoryTest {
 
     @Autowired
     private StoreRepository storeRepository;

--- a/src/test/java/com/sparta/tdd/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sparta/tdd/domain/user/repository/UserRepositoryTest.java
@@ -2,23 +2,14 @@ package com.sparta.tdd.domain.user.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.sparta.tdd.common.template.RepositoryTest;
 import com.sparta.tdd.domain.user.entity.User;
 import com.sparta.tdd.domain.user.enums.UserAuthority;
-import com.sparta.tdd.global.config.AuditConfig;
-import com.sparta.tdd.global.config.QueryDSLConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("local")
-@Import({AuditConfig.class, QueryDSLConfig.class})
-class UserRepositoryTest {
+class UserRepositoryTest extends RepositoryTest {
 
     private User user;
     @Autowired


### PR DESCRIPTION
## PR 내용
현재 아직까지는 배포를 진행하지 않았기 때문에 우선적으로 CI 워크플로우만 작성하게 되었습니다.

- [chore(ci): CI 파이프라인 작성](https://github.com/Sparta-21/TDD/commit/9cb7e8fa6e19d8ca8f7c54342778bed169a90473)
  - main/dev 푸쉬 이벤트 발생 및 main/dev를 향하는 PR이 작성될 경우 동작하게 됩니다.
  - Gradle 의존성 다운로드 받는 부분은 캐싱해 테스트 시간을 단축할 수 있도록 했습니다.
  - 테스트 실행 성공 및 컴파일이 정상적으로 가능한 지 테스트하도록 했습니다.

## 추가 변경 사항
- CI 파이프라인이 동작하기 위해서는 테스트 코드가 모두 통과되어야 하기 때문에, 불통과하는 테스트 코드를 수정했습니다.
- 기존 데이터 정리 작업이 `@BeforeEach` 로 되어 있는 부분을, 메서드명을 `tearDown()` 으로 변경하며, 이에 알맞게 `@AfterEach` 사용으로 수정했습니다.
- 테스트 환경에서 임의로 GOOGLE AI 관련 API 키를 주입하기 위해 application.yml에서 관리하도록 변경했습니다.