### PR TITLE
feat(order): 주문상태변경 API 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -4,24 +4,31 @@ import com.sparta.tdd.domain.auth.UserDetailsImpl;
 import com.sparta.tdd.domain.order.dto.OrderRequestDto;
 import com.sparta.tdd.domain.order.dto.OrderResponseDto;
 import com.sparta.tdd.domain.order.dto.OrderSearchOptionDto;
+import com.sparta.tdd.domain.order.dto.OrderStatusRequestDto;
+import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -30,23 +37,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 public class OrderController {
-
     private final OrderService orderService;
+
+    List<Integer> allowedSizes = List.of(10, 30, 50);
 
     @GetMapping
     public ResponseEntity<Page<OrderResponseDto>> getOrders(
         @ModelAttribute @Valid OrderSearchOptionDto searchOption,
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PageableDefault Pageable pageable) {
-        log.info("Controller.getOrders 요청 수신");
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+        Pageable pageable) {
+        int size = allowedSizes.contains(pageable.getPageSize())
+            ? pageable.getPageSize()
+            : 10;
+
+        Pageable fixedPageable = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
 
         Page<OrderResponseDto> responseDtos = orderService.getOrders(
             userDetails,
-            pageable,
+            fixedPageable,
             searchOption
         );
 
-        log.info("Controller.getOrders 요청 종료");
         return ResponseEntity.ok(responseDtos);
     }
 
@@ -54,14 +66,12 @@ public class OrderController {
     public ResponseEntity<OrderResponseDto> getOrder(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable UUID orderId) {
-        log.info("Controller.getOrder 요청수신");
 
         OrderResponseDto responseDto = orderService.getOrder(
             userDetails,
             orderId
         );
 
-        log.info("Controller.getOrder 요청 종료");
         return ResponseEntity.ok(responseDto);
     }
 
@@ -70,7 +80,6 @@ public class OrderController {
     public ResponseEntity<OrderResponseDto> createOrder(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestBody @Valid OrderRequestDto reqDto) {
-        log.info("Controller.createOrder 요청수신");
         OrderResponseDto resDto = orderService.createOrder(
             userDetails,
             reqDto
@@ -78,9 +87,32 @@ public class OrderController {
 
         URI location = URI.create("/v1/orders/" + resDto.id());
 
-        log.info("Controller.createOrder 요청종료, Created URI: {}, ", location);
         return ResponseEntity
             .created(location)
             .body(resDto);
+    }
+
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER', 'OWNER')")
+    @PatchMapping("/{orderId}/next-status")
+    public ResponseEntity<OrderResponseDto> nextOrderStatus(
+        @PathVariable UUID orderId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        OrderResponseDto res = orderService.nextOrderStatus(orderId, userDetails);
+
+        return ResponseEntity
+            .ok(res);
+    }
+
+    @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @PatchMapping("/{orderId}")
+    public ResponseEntity<OrderResponseDto> updateOrderStatus(
+        @PathVariable UUID orderId,
+        @RequestBody @Valid OrderStatusRequestDto reqDto
+    ) {
+        OrderResponseDto res = orderService.changeOrderStatus(orderId, reqDto);
+
+        return ResponseEntity
+            .ok(res);
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderRequestDto.java
@@ -4,6 +4,7 @@ import com.sparta.tdd.domain.orderMenu.dto.OrderMenuRequestDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import java.util.Set;
@@ -12,7 +13,7 @@ import java.util.UUID;
 public record OrderRequestDto(
     @NotBlank String address,
     @NotBlank String customerName,
-    @NotBlank UUID  storeId,
+    @NotNull UUID  storeId,
     @NotBlank String storeName,
     @PositiveOrZero Integer price,
     @NotEmpty @Valid List<OrderMenuRequestDto> menu

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderStatusRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderStatusRequestDto.java
@@ -2,9 +2,10 @@ package com.sparta.tdd.domain.order.dto;
 
 import com.sparta.tdd.domain.order.enums.OrderStatus;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record OrderStatusRequestDto(
-    @NotBlank OrderStatus orderStatus
+    @NotNull OrderStatus orderStatus
 ) {
 
 }

--- a/src/main/java/com/sparta/tdd/domain/order/dto/OrderStatusRequestDto.java
+++ b/src/main/java/com/sparta/tdd/domain/order/dto/OrderStatusRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.tdd.domain.order.dto;
+
+import com.sparta.tdd.domain.order.enums.OrderStatus;
+import jakarta.validation.constraints.NotBlank;
+
+public record OrderStatusRequestDto(
+    @NotBlank OrderStatus orderStatus
+) {
+
+}

--- a/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
@@ -81,4 +81,10 @@ public class Order extends BaseEntity {
         this.orderMenuList.add(orderMenu);
         orderMenu.assignOrder(this);
     }
+    public void nextStatus() {
+        this.orderStatus = this.orderStatus.next();
+    }
+    public void changeOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/enums/OrderStatus.java
+++ b/src/main/java/com/sparta/tdd/domain/order/enums/OrderStatus.java
@@ -1,6 +1,25 @@
 package com.sparta.tdd.domain.order.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OrderStatus {
-    PENDING,
-    DELIVERED
+    PENDING("대기") {
+        @Override
+        public OrderStatus next() {
+            return DELIVERED;
+        }
+    },
+    DELIVERED("배달완료") {
+        @Override
+        public OrderStatus next() {
+            throw new IllegalStateException("이미 배달완료된 주문은 더 이상 변경 불가합니다");
+        }
+    };
+
+    private final String description;
+
+    public abstract OrderStatus next();
 }

--- a/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/OrderRepository.java
@@ -4,13 +4,12 @@ import com.sparta.tdd.domain.order.entity.Order;
 import java.util.Collection;
 import java.util.List;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -38,6 +37,15 @@ public interface OrderRepository extends JpaRepository<Order, UUID>, OrderReposi
           where o.id in :ids
         """)
     List<Order> findDetailsByIdIn(Collection<UUID> ids);
+
+    @Query("""
+        select o
+        from Order o
+        join fetch o.store s
+        where o.id = :orderId
+        and s.user.id = :userId
+        """)
+    Optional<Order> findOrderByIdAndStoreUserId(UUID orderId, Long userId);
 }
 
 

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -43,7 +43,7 @@ public class OrderService {
         Pageable pageable,
         OrderSearchOptionDto searchOption) {
 
-        hasPermission(userDetails, searchOption);
+        hasPermission(userDetails, searchOption.userId());
 
         //region 조회
         Page<UUID> idPage = orderRepository.findPageIds(
@@ -56,17 +56,6 @@ public class OrderService {
 
         List<OrderResponseDto> content = orderMapper.toResponseList(loaded, idPage);
         return new PageImpl<>(content, pageable, idPage.getTotalElements());
-    }
-
-    private void hasPermission(
-            UserDetailsImpl userDetails,
-            OrderSearchOptionDto searchOption) {
-
-        if (UserAuthority.isCustomer(userDetails.getUserAuthority())
-        && !userDetails.getUserId().equals(searchOption.userId())) {
-            throw new BusinessException(ErrorCode.ORDER_PERMISSION_DENIED);
-        }
-
     }
 
     private void hasPermission(

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -157,8 +157,9 @@ public class OrderService {
     }
 
     /**
-     * OWNER 권한을 가진 유저 - Store.User.id 를 비교하여 동일하지 않으면 예외처리 (repo 에서 가져온 order 가 없음) </br>
-     * MANAGER, MASTER - 별도 join 쿼리 없이 order 객체 조회
+     * OWNER 권한을 가진 유저 - Store.User.id 를 비교하여 동일하지 않으면 예외처리 (repo 에서 가져온 order 가 없음) </br> MANAGER,
+     * MASTER - 별도 join 쿼리 없이 order 객체 조회
+     *
      * @param orderId
      * @param userDetails
      * @return Entity
@@ -168,9 +169,9 @@ public class OrderService {
             return orderRepository.findOrderByIdAndStoreUserId(orderId,
                     userDetails.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("본인 가게의 주문만 접근 가능합니다"));
-        } else {
-            return orderRepository.findDetailById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문내역을 찾을 수 없습니다"));
         }
+        return orderRepository.findDetailById(orderId)
+            .orElseThrow(() -> new IllegalArgumentException("주문내역을 찾을 수 없습니다"));
+
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -6,11 +6,10 @@ import com.sparta.tdd.domain.menu.repository.MenuRepository;
 import com.sparta.tdd.domain.order.dto.OrderRequestDto;
 import com.sparta.tdd.domain.order.dto.OrderResponseDto;
 import com.sparta.tdd.domain.order.dto.OrderSearchOptionDto;
+import com.sparta.tdd.domain.order.dto.OrderStatusRequestDto;
 import com.sparta.tdd.domain.order.entity.Order;
 import com.sparta.tdd.domain.order.mapper.OrderMapper;
 import com.sparta.tdd.domain.order.repository.OrderRepository;
-import com.sparta.tdd.domain.orderMenu.dto.OrderMenuRequestDto;
-import com.sparta.tdd.domain.orderMenu.entity.OrderMenu;
 import com.sparta.tdd.domain.store.entity.Store;
 import com.sparta.tdd.domain.store.repository.StoreRepository;
 import com.sparta.tdd.domain.user.entity.User;
@@ -18,8 +17,6 @@ import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
 
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -32,8 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 public class OrderService {
-    private final OrderRepository orderRepository;
 
+    private final OrderRepository orderRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
     private final OrderMapper orderMapper;
@@ -60,28 +57,6 @@ public class OrderService {
         return new PageImpl<>(content, pageable, idPage.getTotalElements());
     }
 
-    private void hasPermission(
-            UserDetailsImpl userDetails,
-            OrderSearchOptionDto searchOption) {
-
-        if (UserAuthority.isCustomer(userDetails.getUserAuthority())
-        && !userDetails.getUserId().equals(searchOption.userId())) {
-            throw new IllegalArgumentException("권한이 없습니다");
-        }
-
-    }
-
-    private void hasPermission(
-            UserDetailsImpl userDetails,
-            Long userId) {
-
-        if (UserAuthority.isCustomer(userDetails.getUserAuthority())
-                && !userDetails.getUserId().equals(userId)) {
-            throw new IllegalArgumentException("권한이 없습니다");
-        }
-
-    }
-
     public OrderResponseDto getOrder(
         UserDetailsImpl userDetails,
         UUID orderId) {
@@ -91,9 +66,7 @@ public class OrderService {
 
         hasPermission(userDetails, order.getUser().getId());
 
-        OrderResponseDto resDto = orderMapper.toResponse(order);
-
-        return resDto;
+        return orderMapper.toResponse(order);
     }
 
     @Transactional
@@ -104,7 +77,8 @@ public class OrderService {
         //region 엔티티 조회
         User foundUser = findEntity(userRepository, userDetails.getUserId());
         Store foundStore = findEntity(storeRepository, reqDto.storeId());
-        List<Menu> menus = menuRepository.findAllVaildMenuIds(reqDto.getMenuIds(), reqDto.storeId());
+        List<Menu> menus = menuRepository.findAllVaildMenuIds(reqDto.getMenuIds(),
+            reqDto.storeId());
         //endregion
 
         verifyOrderMenus(menus, reqDto.getMenuIds());
@@ -113,28 +87,65 @@ public class OrderService {
 
         Order savedOrder = orderRepository.save(order);
 
-        OrderResponseDto resDto = orderMapper.toResponse(savedOrder);
+        return orderMapper.toResponse(savedOrder);
+    }
 
-        return resDto;
+    @Transactional
+    public OrderResponseDto nextOrderStatus(UUID orderId, UserDetailsImpl userDetails) {
+        Order targetOrder = findAccessibleOrder(orderId, userDetails);
+
+        targetOrder.nextStatus();
+
+        return orderMapper.toResponse(targetOrder);
+    }
+
+    @Transactional
+    public OrderResponseDto changeOrderStatus(UUID orderId, OrderStatusRequestDto reqDto) {
+        Order targetOrder = findEntity(orderRepository, orderId);
+
+        targetOrder.changeOrderStatus(reqDto.orderStatus());
+
+        return orderMapper.toResponse(targetOrder);
+    }
+
+    private void hasPermission(
+        UserDetailsImpl userDetails,
+        OrderSearchOptionDto searchOption) {
+
+        if (UserAuthority.isCustomer(userDetails.getUserAuthority())
+            && !userDetails.getUserId().equals(searchOption.userId())) {
+            throw new IllegalArgumentException("권한이 없습니다");
+        }
+
+    }
+
+    private void hasPermission(
+        UserDetailsImpl userDetails,
+        Long userId) {
+
+        if (UserAuthority.isCustomer(userDetails.getUserAuthority())
+            && !userDetails.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("권한이 없습니다");
+        }
+
     }
 
     /**
      * Dto 와 repository 조회 결과를 비교해서 누락된 메뉴가 있는지 검증
-     * @param menus repository 에서 조회된 menuId, Menu map
+     *
+     * @param menus          repository 에서 조회된 menuId, Menu map
      * @param menuIdsFromDto Dto 에서 넘어온 menuId 들
      */
     private void verifyOrderMenus(
-            List<Menu> menus,
-            Set<UUID> menuIdsFromDto) {
+        List<Menu> menus,
+        Set<UUID> menuIdsFromDto) {
         if (menus.size() != menuIdsFromDto.size()) {
             throw new IllegalArgumentException("메뉴 정보가 올바르지 않습니다");
         }
     }
 
     /**
-     * 특정 레포지토리의 id 탐색결과를 Optional로 받아</br>
-     * null 이면 예외를 발생</br>
-     * 값이 존재한다면 Entity 를 반환합니다
+     * 특정 레포지토리의 id 탐색결과를 Optional로 받아</br> null 이면 예외를 발생</br> 값이 존재한다면 Entity 를 반환합니다
      *
      * @param jpaRepository
      * @param id
@@ -143,5 +154,23 @@ public class OrderService {
     private <T, ID> T findEntity(JpaRepository<T, ID> jpaRepository, ID id) {
         return jpaRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 id 입니다"));
+    }
+
+    /**
+     * OWNER 권한을 가진 유저 - Store.User.id 를 비교하여 동일하지 않으면 예외처리 (repo 에서 가져온 order 가 없음) </br>
+     * MANAGER, MASTER - 별도 join 쿼리 없이 order 객체 조회
+     * @param orderId
+     * @param userDetails
+     * @return Entity
+     */
+    private Order findAccessibleOrder(UUID orderId, UserDetailsImpl userDetails) {
+        if (UserAuthority.isOwner(userDetails.getUserAuthority())) {
+            return orderRepository.findOrderByIdAndStoreUserId(orderId,
+                    userDetails.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("본인 가게의 주문만 접근 가능합니다"));
+        } else {
+            return orderRepository.findDetailById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문내역을 찾을 수 없습니다"));
+        }
     }
 }


### PR DESCRIPTION

상태전이
상태변경
두 가지 기능의 API 작성하였습니다
나눈 이유는 OWNER 는 서버의 규칙에 따라서만 Order 의 상태를 변경할 수 있게 제약을 두고 싶고, 관리자 급은 임의 변경이 가능하게 두가지로 분리해서 작성하였습니다

상태전이 같은 경우는 
Enum 이 상태전이 관련된 로직을 책임지고있고
Order Entity 에서는 객체 상태만 변경되는 메서드를 가지고 있습니다

OrderService 에서 OWNER 권한을 가진 이용자는 자신이 소유한 가게의 주문만 변경 가능하도록 repository 필터를 걸어서 데이터를 가져오게 됩니다

추가로 Page 기본값 적용하였습니다