### PR TITLE
feat(menu): 통합 테스트 작성 및 기타 수정

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
@@ -15,7 +15,7 @@ public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositor
 
     List<Menu> findAllByStoreId(UUID storeId);
 
-    Optional<Menu> findByStoreIdAndIdAndIsDeletedFalse(UUID storeId, UUID menuId);
+    Optional<Menu> findByStoreIdAndMenuIdAndIsDeletedFalse(UUID storeId, UUID menuId);
 
     List<Menu> findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(UUID storeId);
 
@@ -28,9 +28,9 @@ public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositor
     );
 
     /**
-     * DTO로부터 전달받은 메뉴 ID들중
-     * 해당 가게에 존재하고, 숨김처리 되지않은 Menu 엔티티들을 조회
-     * @param storeId 가게 ID
+     * DTO로부터 전달받은 메뉴 ID들중 해당 가게에 존재하고, 숨김처리 되지않은 Menu 엔티티들을 조회
+     *
+     * @param storeId        가게 ID
      * @param menuIdsFromDto DTO로부터 전달받은 메뉴 ID들
      * @return List<Menu> Entity List
      */
@@ -41,5 +41,5 @@ public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositor
             AND m.store.id = :storeId
             AND m.isHidden = false
         """)
-   List<Menu> findAllVaildMenuIds(Set<UUID> menuIdsFromDto, UUID storeId);
+    List<Menu> findAllVaildMenuIds(Set<UUID> menuIdsFromDto, UUID storeId);
 }

--- a/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/repository/MenuRepository.java
@@ -1,9 +1,9 @@
 package com.sparta.tdd.domain.menu.repository;
 
 import com.sparta.tdd.domain.menu.entity.Menu;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,9 +14,9 @@ public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositor
 
     List<Menu> findAllByStoreId(UUID storeId);
 
-    Optional<Menu> findByStoreIdAndId(UUID storeId, UUID menuId);
+    Optional<Menu> findByStoreIdAndIdAndIsDeletedFalse(UUID storeId, UUID menuId);
 
-    List<Menu> findAllByStoreIdAndIsHiddenFalse(UUID storeId);
+    List<Menu> findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(UUID storeId);
 
     @Modifying
     @Query("UPDATE Menu m SET m.deletedAt = :deletedAt, m.deletedBy = :deletedBy WHERE m.store.id IN :storeIds AND m.deletedAt IS NULL")

--- a/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
@@ -27,7 +27,8 @@ public class MenuService {
     public List<MenuResponseDto> getMenus(UUID storeId, UserAuthority authority) {
         List<Menu> menus;
         if (authority.isCustomerOrManager()) {
-            menus = menuRepository.findAllByStoreIdAndIsHiddenFalse(storeId);
+            menus = menuRepository.findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(
+                storeId);
         } else {
             menus = menuRepository.findAllByStoreId(storeId);
         }
@@ -87,7 +88,7 @@ public class MenuService {
     }
 
     private Menu findMenu(UUID storeId, UUID menuId) {
-        return menuRepository.findByStoreIdAndId(storeId, menuId)
+        return menuRepository.findByStoreIdAndIdAndIsDeletedFalse(storeId, menuId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다."));
     }
 

--- a/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/tdd/domain/menu/service/MenuService.java
@@ -88,7 +88,7 @@ public class MenuService {
     }
 
     private Menu findMenu(UUID storeId, UUID menuId) {
-        return menuRepository.findByStoreIdAndIdAndIsDeletedFalse(storeId, menuId)
+        return menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(storeId, menuId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메뉴입니다."));
     }
 

--- a/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
@@ -112,13 +112,10 @@ public class MenuIntegrationTest extends IntegrationTest {
                         .content(mapper.writeValueAsString(dto))
                         .with(csrf()))
                 .andExpectAll(status().isCreated(),
-                    jsonPath("$.name").value("menu1"),
-                    jsonPath("$.description").value("this is menu1"),
-                    jsonPath("$.price").value(15000),
-                    jsonPath("$.imageUrl").value("this is image url"))
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
+                    jsonPath("$.name").value(dto.name()),
+                    jsonPath("$.description").value(dto.description()),
+                    jsonPath("$.price").value(dto.price()),
+                    jsonPath("$.imageUrl").value(dto.imageUrl()));
         }
 
         @Test
@@ -177,10 +174,10 @@ public class MenuIntegrationTest extends IntegrationTest {
                     get("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
                         .with(csrf()))
                 .andExpectAll(status().isOk(),
-                    jsonPath("$.name").value("menu update"),
-                    jsonPath("$.description").value("this is menu update"),
-                    jsonPath("$.price").value(10000),
-                    jsonPath("$.imageUrl").value("this is image url update"));
+                    jsonPath("$.name").value(dto.name()),
+                    jsonPath("$.description").value(dto.description()),
+                    jsonPath("$.price").value(dto.price()),
+                    jsonPath("$.imageUrl").value(dto.imageUrl()));
         }
 
         @Test

--- a/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
@@ -1,0 +1,293 @@
+package com.sparta.tdd.domain.menu;
+
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sparta.tdd.common.helper.CustomWithMockUser;
+import com.sparta.tdd.common.template.IntegrationTest;
+import com.sparta.tdd.domain.menu.dto.MenuRequestDto;
+import com.sparta.tdd.domain.menu.entity.Menu;
+import com.sparta.tdd.domain.menu.repository.MenuRepository;
+import com.sparta.tdd.domain.store.entity.Store;
+import com.sparta.tdd.domain.store.enums.StoreCategory;
+import com.sparta.tdd.domain.store.repository.StoreRepository;
+import com.sparta.tdd.domain.user.entity.User;
+import com.sparta.tdd.domain.user.enums.UserAuthority;
+import com.sparta.tdd.domain.user.repository.UserRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+public class MenuIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    User owner;
+    User customer;
+    Store store;
+    Menu menu;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.cleanUp.all();
+        customer = User.builder()
+            .username("customer")
+            .password("password1")
+            .nickname("test1")
+            .authority(UserAuthority.CUSTOMER)
+            .build();
+        userRepository.save(customer);
+
+        owner = User.builder()
+            .username("owner")
+            .password("password2")
+            .nickname("test2")
+            .authority(UserAuthority.OWNER)
+            .build();
+        userRepository.save(owner);
+
+        store = Store.builder()
+            .name("store")
+            .category(StoreCategory.KOREAN)
+            .description("this is store description")
+            .imageUrl("this is image url")
+            .user(owner)
+            .build();
+        storeRepository.save(store);
+
+        MenuRequestDto dto = MenuRequestDto.builder()
+            .name("menu")
+            .description("this is menu")
+            .price(30000)
+            .imageUrl("this is image url")
+            .build();
+
+        menu = Menu.builder()
+            .dto(dto)
+            .store(store)
+            .build();
+        menuRepository.save(menu);
+    }
+
+    @Nested
+    @DisplayName("메뉴 등록 테스트")
+    class createMenu {
+
+        @Test
+        @CustomWithMockUser(userId = 2L, username = "owner", authority = UserAuthority.OWNER)
+        @DisplayName("OWNER 메뉴 등록 성공")
+        void ownerCreatesMenu() throws Exception {
+            // given
+            UUID storeId = store.getId();
+
+            MenuRequestDto dto = MenuRequestDto.builder()
+                .name("menu1")
+                .description("this is menu1")
+                .price(15000)
+                .imageUrl("this is image url")
+                .build();
+
+            // when & then
+            mockMvc.perform(
+                    post("/v1/store/{storeId}/menu", storeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(csrf()))
+                .andExpectAll(status().isCreated(),
+                    jsonPath("$.name").value("menu1"),
+                    jsonPath("$.description").value("this is menu1"),
+                    jsonPath("$.price").value(15000),
+                    jsonPath("$.imageUrl").value("this is image url"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        }
+
+        @Test
+        @CustomWithMockUser(username = "customer")
+        @DisplayName("CUSTOMER 메뉴 등록 실패")
+        void customerCreatesMenu() throws Exception {
+            // given
+            UUID storeId = store.getId();
+
+            MenuRequestDto dto = MenuRequestDto.builder()
+                .name("menu1")
+                .description("this is menu1")
+                .price(15000)
+                .imageUrl("this is image url")
+                .build();
+
+            // when & then
+            mockMvc.perform(
+                    post("/v1/store/{storeId}/menu", storeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 수정 테스트")
+    class updateMenu {
+
+        @Test
+        @CustomWithMockUser(userId = 2L, username = "owner", authority = UserAuthority.OWNER)
+        @DisplayName("OWNER 메뉴 수정 성공")
+        void ownerUpdatesMenu() throws Exception {
+            // given
+            UUID storeId = store.getId();
+            UUID menuId = menu.getId();
+
+            MenuRequestDto dto = MenuRequestDto.builder()
+                .name("menu update")
+                .description("this is menu update")
+                .price(10000)
+                .imageUrl("this is image url update")
+                .build();
+
+            // when & then
+            mockMvc.perform(
+                    patch("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(csrf()))
+                .andExpectAll(status().isNoContent());
+
+            // then
+            mockMvc.perform(
+                    get("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .with(csrf()))
+                .andExpectAll(status().isOk(),
+                    jsonPath("$.name").value("menu update"),
+                    jsonPath("$.description").value("this is menu update"),
+                    jsonPath("$.price").value(10000),
+                    jsonPath("$.imageUrl").value("this is image url update"));
+        }
+
+        @Test
+        @CustomWithMockUser(username = "customer")
+        @DisplayName("CUSTOMER 메뉴 수정 실패")
+        void customerUpdatesMenu() throws Exception {
+            // given
+            UUID storeId = store.getId();
+            UUID menuId = menu.getId();
+
+            MenuRequestDto dto = MenuRequestDto.builder()
+                .name("menu update")
+                .description("this is menu update")
+                .price(10000)
+                .imageUrl("this is image url update")
+                .build();
+
+            // when & then
+            mockMvc.perform(
+                    patch("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @CustomWithMockUser(userId = 2L, username = "owner", authority = UserAuthority.OWNER)
+        @DisplayName("OWNER 메뉴 상태 수정 성공")
+        void ownerUpdatesMenuStatus() throws Exception {
+            // given
+            UUID storeId = store.getId();
+            UUID menuId = menu.getId();
+
+            // when & then
+            mockMvc.perform(
+                    patch("/v1/store/{storeId}/menu/{menuId}/status", storeId, menuId)
+                        .param("status", "true")
+                        .with(csrf()))
+                .andExpectAll(status().isNoContent());
+
+            // then
+            mockMvc.perform(
+                    get("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .with(csrf()))
+                .andExpectAll(status().isOk(),
+                    jsonPath("$.isHidden").value(Boolean.TRUE));
+        }
+
+        @Test
+        @CustomWithMockUser(username = "customer")
+        @DisplayName("CUSTOMER 메뉴 상태 수정 실패")
+        void customerUpdatesMenuStatus() throws Exception {
+            // given
+            UUID storeId = store.getId();
+            UUID menuId = menu.getId();
+
+            // when
+            mockMvc.perform(
+                    patch("/v1/store/{storeId}/menu/{menuId}/status", storeId, menuId)
+                        .param("status", "true")
+                        .with(csrf()))
+                .andExpectAll(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("메뉴 삭제 테스트")
+    class deleteMenu {
+
+        @Test
+        @Disabled
+        @CustomWithMockUser(userId = 2L, username = "owner", authority = UserAuthority.OWNER)
+        @DisplayName("OWNER 메뉴 삭제 성공")
+        void ownerDeletesMenu() throws Exception {
+            // given
+            UUID storeId = store.getId();
+            UUID menuId = menu.getId();
+
+            // when & then
+            mockMvc.perform(
+                    delete("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .with(csrf()))
+                .andExpectAll(status().isNoContent());
+
+            // then todo: GET 메서드 수정 후 적용해야함
+            mockMvc.perform(
+                    patch("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .with(csrf()))
+                .andExpectAll(status().isNotFound());
+        }
+
+        @Test
+        @CustomWithMockUser(username = "customer")
+        @DisplayName("CUSTOMER 메뉴 삭제 실패")
+        void customerDeletesMenu() throws Exception {
+            //given
+            UUID storeId = store.getId();
+            UUID menuId = menu.getId();
+
+            // when & then
+            mockMvc.perform(
+                    delete("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                        .with(csrf()))
+                .andExpectAll(status().isForbidden());
+        }
+    }
+
+}

--- a/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/MenuIntegrationTest.java
@@ -22,7 +22,6 @@ import com.sparta.tdd.domain.user.enums.UserAuthority;
 import com.sparta.tdd.domain.user.repository.UserRepository;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -253,7 +252,6 @@ public class MenuIntegrationTest extends IntegrationTest {
     class deleteMenu {
 
         @Test
-        @Disabled
         @CustomWithMockUser(userId = 2L, username = "owner", authority = UserAuthority.OWNER)
         @DisplayName("OWNER 메뉴 삭제 성공")
         void ownerDeletesMenu() throws Exception {
@@ -267,11 +265,11 @@ public class MenuIntegrationTest extends IntegrationTest {
                         .with(csrf()))
                 .andExpectAll(status().isNoContent());
 
-            // then todo: GET 메서드 수정 후 적용해야함
+            // then
             mockMvc.perform(
-                    patch("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
+                    get("/v1/store/{storeId}/menu/{menuId}", storeId, menuId)
                         .with(csrf()))
-                .andExpectAll(status().isNotFound());
+                .andExpectAll(status().isBadRequest());
         }
 
         @Test

--- a/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
@@ -121,7 +121,7 @@ public class MenuServiceTest {
         @DisplayName("Customer 메뉴 목록 조회 테스트")
         void getMenusCustomerTest() {
             // given
-            when(menuRepository.findAllByStoreIdAndIsHiddenFalse(store.getId()))
+            when(menuRepository.findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(store.getId()))
                 .thenReturn(List.of(menu1));
 
             // when
@@ -130,7 +130,8 @@ public class MenuServiceTest {
 
             // then
             assertNotNull(testMenus);
-            verify(menuRepository, times(1)).findAllByStoreIdAndIsHiddenFalse(store.getId());
+            verify(menuRepository, times(1)).findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(
+                store.getId());
             verify(menuRepository, never()).findAllByStoreId(any());
             assertTrue(testMenus.stream().anyMatch(m -> m.menuId().equals(menu1.getId())));
             assertTrue(testMenus.stream().noneMatch(m -> m.menuId().equals(menu2.getId())));
@@ -150,7 +151,8 @@ public class MenuServiceTest {
             // then
             assertNotNull(testMenus);
             verify(menuRepository, times(1)).findAllByStoreId(store.getId());
-            verify(menuRepository, never()).findAllByStoreIdAndIsHiddenFalse(any());
+            verify(menuRepository, never()).findAllByStoreIdAndIsHiddenFalseAndIsDeletedFalse(
+                any());
             assertTrue(testMenus.stream().anyMatch(m -> m.menuId().equals(menu1.getId())));
             assertTrue(testMenus.stream().anyMatch(m -> m.menuId().equals(menu2.getId())));
         }
@@ -164,21 +166,22 @@ public class MenuServiceTest {
         @DisplayName("Customer 메뉴 상세 테스트")
         void getMenusCustomerTest() {
             //given
-            when(menuRepository.findByStoreIdAndId(store.getId(), menu2.getId()))
+            when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu2.getId()))
                 .thenReturn(Optional.of(menu2));
 
             // when & then
             assertThrows(IllegalArgumentException.class,
                 () -> menuService.getMenu(store.getId(), menu2.getId(),
                     customer.getAuthority()));
-            verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu2.getId());
+            verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+                menu2.getId());
         }
 
         @Test
         @DisplayName("OWNER 메뉴 상세 테스트")
         void getMenusOwnerTest() {
             //given
-            when(menuRepository.findByStoreIdAndId(store.getId(), menu2.getId()))
+            when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu2.getId()))
                 .thenReturn(Optional.of(menu2));
 
             // when
@@ -188,7 +191,8 @@ public class MenuServiceTest {
             // then
             assertNotNull(testMenu);
             assertEquals(menu2.getId(), testMenu.menuId());
-            verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu2.getId());
+            verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+                menu2.getId());
         }
 
     }
@@ -220,7 +224,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 수정 테스트")
     void updateMenuSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndId(store.getId(), menu1.getId()))
+        when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu1.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -229,7 +233,8 @@ public class MenuServiceTest {
         menuService.updateMenu(store.getId(), menu1.getId(), dto3, 2L);
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu1.getId());
+        verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+            menu1.getId());
         assertEquals(dto3.name(), menu1.getName());
         assertEquals(dto3.description(), menu1.getDescription());
         assertEquals(dto3.price(), menu1.getPrice());
@@ -241,7 +246,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 상태 수정 테스트")
     void updateMenuStatusSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndId(store.getId(), menu1.getId()))
+        when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu1.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -250,7 +255,8 @@ public class MenuServiceTest {
         menuService.updateMenuStatus(store.getId(), menu1.getId(), Boolean.TRUE, 2L);
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu1.getId());
+        verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+            menu1.getId());
         assertTrue(menu1.isHidden());
     }
 
@@ -258,7 +264,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 삭제 테스트(soft delete)")
     void deleteMenuSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndId(store.getId(), menu1.getId()))
+        when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu1.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -267,7 +273,8 @@ public class MenuServiceTest {
         menuService.deleteMenu(store.getId(), menu1.getId(), owner.getId());
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndId(store.getId(), menu1.getId());
+        verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+            menu1.getId());
         assertNotNull(menu1.getDeletedAt());
         assertEquals(owner.getId(), menu1.getDeletedBy());
     }

--- a/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/sparta/tdd/domain/menu/service/MenuServiceTest.java
@@ -166,14 +166,15 @@ public class MenuServiceTest {
         @DisplayName("Customer 메뉴 상세 테스트")
         void getMenusCustomerTest() {
             //given
-            when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu2.getId()))
+            when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
+                menu2.getId()))
                 .thenReturn(Optional.of(menu2));
 
             // when & then
             assertThrows(IllegalArgumentException.class,
                 () -> menuService.getMenu(store.getId(), menu2.getId(),
                     customer.getAuthority()));
-            verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+            verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
                 menu2.getId());
         }
 
@@ -181,7 +182,8 @@ public class MenuServiceTest {
         @DisplayName("OWNER 메뉴 상세 테스트")
         void getMenusOwnerTest() {
             //given
-            when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu2.getId()))
+            when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
+                menu2.getId()))
                 .thenReturn(Optional.of(menu2));
 
             // when
@@ -191,7 +193,7 @@ public class MenuServiceTest {
             // then
             assertNotNull(testMenu);
             assertEquals(menu2.getId(), testMenu.menuId());
-            verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+            verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
                 menu2.getId());
         }
 
@@ -224,7 +226,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 수정 테스트")
     void updateMenuSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu1.getId()))
+        when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(), menu1.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -233,7 +235,7 @@ public class MenuServiceTest {
         menuService.updateMenu(store.getId(), menu1.getId(), dto3, 2L);
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+        verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
             menu1.getId());
         assertEquals(dto3.name(), menu1.getName());
         assertEquals(dto3.description(), menu1.getDescription());
@@ -246,7 +248,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 상태 수정 테스트")
     void updateMenuStatusSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu1.getId()))
+        when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(), menu1.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -255,7 +257,7 @@ public class MenuServiceTest {
         menuService.updateMenuStatus(store.getId(), menu1.getId(), Boolean.TRUE, 2L);
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+        verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
             menu1.getId());
         assertTrue(menu1.isHidden());
     }
@@ -264,7 +266,7 @@ public class MenuServiceTest {
     @DisplayName("메뉴 삭제 테스트(soft delete)")
     void deleteMenuSuccessTest() {
         // given
-        when(menuRepository.findByStoreIdAndIdAndIsDeletedFalse(store.getId(), menu1.getId()))
+        when(menuRepository.findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(), menu1.getId()))
             .thenReturn(Optional.of(menu1));
         when(userRepository.findById(2L)).thenReturn(Optional.of(owner));
         when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
@@ -273,7 +275,7 @@ public class MenuServiceTest {
         menuService.deleteMenu(store.getId(), menu1.getId(), owner.getId());
 
         // then
-        verify(menuRepository, times(1)).findByStoreIdAndIdAndIsDeletedFalse(store.getId(),
+        verify(menuRepository, times(1)).findByStoreIdAndMenuIdAndIsDeletedFalse(store.getId(),
             menu1.getId());
         assertNotNull(menu1.getDeletedAt());
         assertEquals(owner.getId(), menu1.getDeletedBy());


### PR DESCRIPTION
## PR내용
[test(menu): 메뉴삭제(owner) 시나리오 제외 모든 api 통합테스트 코드 작성](https://github.com/Sparta-21/TDD/commit/7f2021598d8b89ba3fbb8bd2cdfea2a57892ed5f)
[test(menu): 메뉴삭제 통합테스트](https://github.com/Sparta-21/TDD/commit/0190ec9d30186dfcee79929b645498800c05d6eb)
조회 관련 API 제외 컨트롤러-서비스 권한 시나리오 통합테스트 작성했습니다.

get 메서드(메뉴 목록 조회, 메뉴 상세 조회)는 권한 처리 로직을 서비스 단위테스트에서 체크했기때문에 통합테스트를 추가작성하지 않았습니다.

---

[fix(menu): 삭제된 메뉴는 보이지 않도록 수정](https://github.com/Sparta-21/TDD/commit/2804ac01d3657ba40823bb3780dbb24df2f89589)
데이터 삭제(soft delete) 후 해당 데이터 조회 시 보이지 않도록 수정했습니다.