### PR TITLE
feat(auditing): SecurityContext 기반 AuditorAware 구현 및 단위 테스트 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/global/config/AuditConfig.java
+++ b/src/main/java/com/sparta/tdd/global/config/AuditConfig.java
@@ -1,10 +1,16 @@
 package com.sparta.tdd.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class AuditConfig {
 
+    @Bean
+    public AuditorAware<Long> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
 }

--- a/src/main/java/com/sparta/tdd/global/config/AuditorAwareImpl.java
+++ b/src/main/java/com/sparta/tdd/global/config/AuditorAwareImpl.java
@@ -1,0 +1,31 @@
+package com.sparta.tdd.global.config;
+
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuditorAwareImpl implements AuditorAware<Long> {
+
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        // SecurityContextHolder 에서 현재 인증 정보를 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증 정보가 없거나 Optional.empty()를 반환
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        // principal이 우리가 정의한 UserDetailsImpl 타입이 아닐 경우 Optional.empty() 반환
+        if (!(principal instanceof UserDetailsImpl userDetails)) {
+            return Optional.empty();
+        }
+
+        // UserDetailsImpl 에서 사용자 ID를 반환
+        return Optional.of(userDetails.getUserId());
+    }
+}

--- a/src/test/java/com/sparta/tdd/global/config/AuditorAwareImplTest.java
+++ b/src/test/java/com/sparta/tdd/global/config/AuditorAwareImplTest.java
@@ -1,0 +1,95 @@
+package com.sparta.tdd.global.config;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sparta.tdd.domain.auth.UserDetailsImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class AuditorAwareImplTest {
+
+    private final AuditorAwareImpl auditorAware = new AuditorAwareImpl();
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setAuth(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("Authentication이 없는 경우")
+    void noAuthentication() {
+        //given
+
+        //when
+        Optional<Long> auditor = auditorAware.getCurrentAuditor();
+
+        //then
+        assertThat(auditor).isEmpty();
+    }
+
+    @Test
+    @DisplayName("인증되지 않는 Authentication 경우")
+    void notAuthenticated(@Mock Authentication auth) {
+        //given
+        given(auth.isAuthenticated()).willReturn(false);
+        setAuth(auth);
+
+        //when
+        Optional<Long> auditor = auditorAware.getCurrentAuditor();
+
+        //then
+        assertThat(auditor).isEmpty();
+        verify(auth).isAuthenticated();
+    }
+
+    @Test
+    @DisplayName("principal이 익명 사용자인 경우")
+    void principalNotUserDetails(@Mock Authentication auth) {
+        //given
+        given(auth.isAuthenticated()).willReturn(true);
+        given(auth.getPrincipal()).willReturn("anonymousUser");
+        setAuth(auth);
+
+        //when
+        Optional<Long> auditor = auditorAware.getCurrentAuditor();
+
+        //then
+        assertThat(auditor).isEmpty();
+        verify(auth).isAuthenticated();
+        verify(auth).getPrincipal();
+    }
+
+    @Test
+    @DisplayName("principal이 UserDetailsImpl 타입 인 경우 해당 userId를 반환")
+    void principalIsUserDetails(@Mock Authentication auth, @Mock UserDetailsImpl userDetails) {
+        //given
+        given(auth.isAuthenticated()).willReturn(true);
+        given(auth.getPrincipal()).willReturn(userDetails);
+        given(userDetails.getUserId()).willReturn(2L);
+        setAuth(auth);
+
+        //when
+        Optional<Long> auditor = auditorAware.getCurrentAuditor();
+
+        //then
+        assertThat(auditor).contains(2L);
+        verify(auth).isAuthenticated();
+        verify(auth).getPrincipal();
+        verify(userDetails, times(1)).getUserId();
+    }
+}


### PR DESCRIPTION
AuditorAwareImpl
- SecurityContextHolder에서 Authentication 획득
- 인증 없음 또는 비인증 상태 시 Optional.empty() 반환
- principal이 UserDetailsImpl가 아니면 Optional.empty() 반환
- principal이 UserDetailsImpl면 userId 반환


create_by, deleted_by, updated_by 
postman으로 들어가는지 확인 완료하였습니다.