### PR TITLE
feat(cd): CD 관련 워크플로우 파일 작성

### DIFF
--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -1,0 +1,107 @@
+name: TDD Project Development Deployment Workflow
+
+on:
+  workflow_run:
+    workflows:
+      - 'TDD Project Integration Workflow'
+    types:
+      - completed
+    branches:
+      - dev
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        default: 'warning'
+permissions:
+  contents: read
+
+jobs:
+  docker-build-push:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    name: Create Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: build docker
+        run: ./gradlew bootBuildImage --imageName=${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Tag Version
+        run: |
+          docker tag ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha || github.sha }} ${{ secrets.DOCKER_REPO }}:latest
+
+      - name: Publish Docker Images
+        run: |
+          docker push ${{ secrets.DOCKER_REPO }}:latest
+          docker push ${{ secrets.DOCKER_REPO }}:${{ github.event.workflow_run.head_sha || github.sha }}
+
+  deploy-to-aws:
+    needs: docker-build-push
+    name: Deploy to AWS Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Get Github Actions IP
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE }}" > .env
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Add Github Actions IP to Security group
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
+      - name: Copy .env to AWS Server
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ secrets.AWS_SSH_HOST }}
+          username: ${{ secrets.AWS_SSH_USERNAME }}
+          key: ${{ secrets.AWS_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.AWS_SSH_PORT }}
+          source: ".env"
+          target: "."
+
+      - name: SSH Commands
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.AWS_SSH_HOST }}
+          username: ${{ secrets.AWS_SSH_USERNAME }}
+          key: ${{ secrets.AWS_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.AWS_SSH_PORT }}
+          script: |
+            trap 'rm -f .env' EXIT
+            ./script.sh
+
+      - name: Remove Github Actions IP From Security Group
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION
## PR 내용

- [feat(cd): CD 관련 워크플로우 파일 작성](https://github.com/Sparta-21/TDD/commit/d2e51499a6d0583393571622b848e62196369c8b)
  - dev 브랜치에 병합된 이후 CI를 통과하게 되면 CD 워크플로우가 동작하도록 설정했습니다.
  - 또한 worflow_dispatch 옵션을 통해 수동실행이 가능하도록 했습니다.
  - 크게 2가지의 동작으로 구분했습니다.
  - 프로젝트 도커파일 생성 및 Docker Hub로 push
    - DockerHub 관련 팀 계정이 존재하지 않아, 제 개인적은 계정으로 진행하도록 설정했습니다.
    - latest 및 커밋 해쉬값을 가진 2개의 도커파일을 모두 빌드에 이전 버전도 관리할 수 있도록 설정했습니다.
  - AWS 서버로 SSH 접속을 통한 배포
    - .env 파일을 ec2 내부에서 관리하는 방법도 존재하지만, Github Secrets를 이용하는 방법을 적용해봤습니다.(관련 내용은 노션에 적어뒀습니다)
    - AWS의 보안그룹에 Github Actions IP가 등록되어 있어야 접속이 가능하므로 이를 추가하고 제거하는 동작을 구성했습니다.
    - Github Secrets에 작성된 .env 파일은 scp-action을 통해 ec2 내부터 복사되고, 이후 이를 활용해 도커 컨테이너로 스프링 서버를 실행합니다.

## 리뷰 포인트
- AWS 관련 내용을 노션 환경변수 아래부분에 따로 정리해두도록 하겠습니다.
- 정상적인 동작을 할 지 테스트를 해보고 싶은데, 로컬에서 불가능하다고 판단되어서 우선 PR부터 작성했습니다. 아마 잦은 수정을 위한 PR이 올라올 것으로 예상됩니다. 양해 부탁드립니다.
- Job 등 워크플로우 파일 내용 관련해서 궁금하신 부분이 있다면 언제든지 여쭤봐주시면 대답해드리겠습니다!