### PR TITLE
feat(coupon): coupon api 외 추가로직 구현

### DIFF
--- a/src/main/java/com/sparta/tdd/TddApplication.java
+++ b/src/main/java/com/sparta/tdd/TddApplication.java
@@ -2,8 +2,10 @@ package com.sparta.tdd;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TddApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/tdd/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/sparta/tdd/domain/coupon/entity/Coupon.java
@@ -85,10 +85,21 @@ public class Coupon extends BaseEntity {
 
     public void issuedCount() {
         this.issuedCount++;
+        if (issuedCount == quantity) {
+            this.delete(null);
+        }
+    }
+
+    public boolean checkIssuedCount() {
+        return this.issuedCount >= this.quantity;
     }
 
     public boolean isAlreadyIssued() {
         return issuedCount > 0;
     }
 
+    public boolean checkMinOrderPrice(Integer minOrderPrice) {
+        return this.minOrderPrice > minOrderPrice;
+
+    }
 }

--- a/src/main/java/com/sparta/tdd/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/sparta/tdd/domain/coupon/entity/UserCoupon.java
@@ -57,7 +57,8 @@ public class UserCoupon extends BaseEntity {
         this.coupon = coupon;
     }
 
-    public void updateStatus(CouponStatus newCouponStatus) {
-        this.couponStatus = newCouponStatus;
+    public void updateStatusUsed() {
+        this.couponStatus = CouponStatus.USED;
+        this.usedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/coupon/repository/CouponRepository.java
@@ -1,14 +1,23 @@
 package com.sparta.tdd.domain.coupon.repository;
 
 import com.sparta.tdd.domain.coupon.entity.Coupon;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CouponRepository extends JpaRepository<Coupon, UUID> {
 
     List<Coupon> findAllByStoreIdAndDeletedAtIsNull(UUID storeId);
 
     Optional<Coupon> findByIdAndDeletedAtIsNull(UUID id);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Coupon c set c.deletedAt = :now, c.deletedBy = null where c.deletedAt is null and c.expiredAt <= :now")
+    int softDeleteExpiredCoupons(@Param("now") LocalDateTime now);
+
 }

--- a/src/main/java/com/sparta/tdd/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/coupon/repository/UserCouponRepository.java
@@ -1,12 +1,22 @@
 package com.sparta.tdd.domain.coupon.repository;
 
 import com.sparta.tdd.domain.coupon.entity.UserCoupon;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, UUID>,
     UserCouponRepositoryCustom {
 
     List<UserCoupon> findAllByUserId(Long userId);
+
+    @Query("update UserCoupon uc set uc.couponStatus = 'EXPIRED' where uc.couponStatus = 'ACTIVE' and uc.coupon.expiredAt <= :now")
+    int expireByCouponExpiredAt(@Param("now") LocalDateTime now);
+
+    @Query("update UserCoupon uc set uc.deletedAt = :now, uc.deletedBy = null where uc.couponStatus = 'EXPIRED' and DATE(uc.coupon.expiredAt) <= DATE(:sevenDaysAgo)")
+    void deleteExpiredUserCoupon(@Param("now") LocalDateTime now,
+        @Param("sevenDaysAgo") LocalDateTime sevenDaysAgo);
 }

--- a/src/main/java/com/sparta/tdd/domain/coupon/scheduler/CouponScheduler.java
+++ b/src/main/java/com/sparta/tdd/domain/coupon/scheduler/CouponScheduler.java
@@ -1,0 +1,35 @@
+package com.sparta.tdd.domain.coupon.scheduler;
+
+import com.sparta.tdd.domain.coupon.repository.CouponRepository;
+import com.sparta.tdd.domain.coupon.repository.UserCouponRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CouponScheduler {
+
+    public final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    // userCoupon 만료 처리 및 만료된 coupon soft delete
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void expireUserCoupons() {
+        LocalDateTime now = LocalDateTime.now();
+        userCouponRepository.expireByCouponExpiredAt(now);
+        couponRepository.softDeleteExpiredCoupons(now);
+    }
+
+    // 만료된 userCoupon 7일 후 soft delete
+    @Scheduled(cron = "0 30 0 * * *")
+    @Transactional
+    public void deleteOldExpiredUserCoupons() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        userCouponRepository.deleteExpiredUserCoupon(now, sevenDaysAgo);
+    }
+}

--- a/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
@@ -58,19 +58,22 @@ public enum ErrorCode {
 
     // AI 도메인 관련
 
-
     // Cart 도메인 관련
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 아이템을 찾을 수 없습니다."),
     CART_ITEM_INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량은 1개 이상이어야 합니다."),
     CART_ITEM_NOT_OWNED(HttpStatus.FORBIDDEN, "본인의 장바구니 아이템만 수정할 수 있습니다."),
-    CART_DIFFERENT_STORE(HttpStatus.BAD_REQUEST, "장바구니에는 한 가게의 메뉴만 담을 수 있습니다. 기존 장바구니를 비우고 다시 시도해주세요."),
+    CART_DIFFERENT_STORE(HttpStatus.BAD_REQUEST,
+        "장바구니에는 한 가게의 메뉴만 담을 수 있습니다. 기존 장바구니를 비우고 다시 시도해주세요."),
 
     // COUPON 도메인 관련
     COUPON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "Scope 설정이 잘못되었습니다."),
     COUPON_ALREADY_ISSUED(HttpStatus.BAD_REQUEST, "이미 사용자가 발급하여 수정할 수 없습니다."),
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 쿠폰입니다."),
-    COUPON_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다.");
+    COUPON_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    COUPON_ALL_SOLD_OUT(HttpStatus.BAD_REQUEST, "쿠폰이 모두 소진되었습니다."),
+    USER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저쿠폰입니다."),
+    COUPON_MIN_PRICE_INVALID(HttpStatus.BAD_REQUEST, "최소금액이 부족합니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
# PR 내용

[feat(coupon): api 외 추가로직 구현(쿠폰 사용, 유저쿠폰 만료 및 쿠폰삭제 스케쥴링, 유저쿠폰 발급 시 조건 추가)
](https://github.com/Sparta-21/TDD/commit/b30982a901ee26c61e1339f7f2d928e0ed613507)

coupon/userCoupon api 외 추가 로직 구현하였습니다.

### 1. 쿠폰 만료 관련 스케쥴링
- 매일 0시 0분, 해당 날짜에 만료되는 유저쿠폰들의 Status를 변경하고(EXPIRED) 만료된 쿠폰은 soft delete 하는 메서드를 추가했습니다.
- 매일 0시 30분, 7일간격으로 만료된 유저쿠폰들을 soft delete하는 메서드를 추가했습니다.
- 스케쥴링시 모두 bulk update하도록 쿼리를 작성했습니다.

### 2. 유저 쿠폰 사용 로직
- 일단 주문 총액(price)를 받아서 쿠폰 적용이 가능한 최소 주문금액이 맞는지 체크하고 할인값 혹은 퍼센트(discountValue)를 넘기는 방식으로 설계했습니다.
- 총 금액을 아예 쿠폰 도메인에서 계산하고 주문쪽으로 넘길지가 고민되어서 이 부분은 관련 담당자분들과 의논해보아야할 것 같습니다.

### 3. 유저 쿠폰 발급(기존 API에서 로직 추가)
- 쿠폰과 issue된 유저쿠폰 수량을 체크하는 로직이 빠져있어서 추가했습니다.

테스트코드는 작성 후 따로 PR 날릴 예정입니다.

추가로, 3번 문제에 대해서는 동시성 이슈 가능성이 예상되는데 시간이 된다면... 부하테스트 진행하며 현재 로직, 비관적 락, 낙관적 락 구현해보며 비교해보고자 합니다. 이 부분은 개인적으로 처음 접하는 거라 혹시 의견이 있으시다면 자유롭게 피드백해주시면 감사하겠습니다!