### PR TITLE
feat(Order): cancel 관련 로직 추가

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -39,23 +39,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
     private final OrderService orderService;
 
-    List<Integer> allowedSizes = List.of(10, 30, 50);
-
     @GetMapping
     public ResponseEntity<Page<OrderResponseDto>> getOrders(
         @ModelAttribute @Valid OrderSearchOptionDto searchOption,
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
         Pageable pageable) {
-        int size = allowedSizes.contains(pageable.getPageSize())
-            ? pageable.getPageSize()
-            : 10;
-
-        Pageable fixedPageable = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
-
         Page<OrderResponseDto> responseDtos = orderService.getOrders(
             userDetails,
-            fixedPageable,
+            pageable,
             searchOption
         );
 

--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -115,4 +115,15 @@ public class OrderController {
         return ResponseEntity
             .ok(res);
     }
+
+    @PatchMapping("/cancel/{orderId}")
+    public ResponseEntity<OrderResponseDto> cancelOrder(
+        @PathVariable UUID orderId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        OrderResponseDto res = orderService.cancelOrder(orderId, userDetails);
+
+        return ResponseEntity
+            .ok(res);
+    }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/tdd/domain/order/controller/OrderController.java
@@ -43,7 +43,6 @@ public class OrderController {
     public ResponseEntity<Page<OrderResponseDto>> getOrders(
         @ModelAttribute @Valid OrderSearchOptionDto searchOption,
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
         Pageable pageable) {
         Page<OrderResponseDto> responseDtos = orderService.getOrders(
             userDetails,

--- a/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/tdd/domain/order/entity/Order.java
@@ -20,6 +20,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -91,5 +93,10 @@ public class Order extends BaseEntity {
 
     public boolean isOwnedBy(Long userId) {
         return this.getUser().getId().equals(userId);
+    }
+
+    public boolean canCancel() {
+        Duration duration = Duration.between(super.getCreatedAt(), LocalDateTime.now());
+        return duration.toMinutes() < 5;
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/enums/OrderStatus.java
+++ b/src/main/java/com/sparta/tdd/domain/order/enums/OrderStatus.java
@@ -6,6 +6,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OrderStatus {
+    CANCELLED("취소됨"){
+        @Override
+        public OrderStatus next() {
+            throw new IllegalStateException("취소된 주문입니다");
+        }
+    },
     PENDING("대기") {
         @Override
         public OrderStatus next() {

--- a/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/tdd/domain/order/repository/querydsl/OrderRepositoryCustomImpl.java
@@ -32,7 +32,8 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
     @Override
     public Optional<Order> findDetailById(UUID id) {
         QOrder qOrder = QOrder.order;
-        QUser qUser = QUser.user;
+        QUser qOrderUser = new QUser("orderUser");
+        QUser qStoreUser = new QUser("storeUser");
         QStore qStore = QStore.store;
         QPayment qPayment = QPayment.payment;
         QOrderMenu qOrderMenu = QOrderMenu.orderMenu;
@@ -41,8 +42,9 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
         Order result = query
             .selectFrom(qOrder)
             .distinct()
-            .leftJoin(qOrder.user, qUser).fetchJoin()
+            .leftJoin(qOrder.user, qOrderUser).fetchJoin()
             .leftJoin(qOrder.store, qStore).fetchJoin()
+            .leftJoin(qOrder.store.user, qStoreUser).fetchJoin()
             .leftJoin(qOrder.payment, qPayment).fetchJoin()
             .leftJoin(qOrder.orderMenuList, qOrderMenu).fetchJoin()
             .leftJoin(qOrderMenu.menu, qMenu).fetchJoin()

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -8,6 +8,7 @@ import com.sparta.tdd.domain.order.dto.OrderResponseDto;
 import com.sparta.tdd.domain.order.dto.OrderSearchOptionDto;
 import com.sparta.tdd.domain.order.dto.OrderStatusRequestDto;
 import com.sparta.tdd.domain.order.entity.Order;
+import com.sparta.tdd.domain.order.enums.OrderStatus;
 import com.sparta.tdd.domain.order.mapper.OrderMapper;
 import com.sparta.tdd.domain.order.repository.OrderRepository;
 import com.sparta.tdd.domain.store.entity.Store;
@@ -62,8 +63,9 @@ public class OrderService {
             UserDetailsImpl userDetails,
             Long userId) {
 
-        if (UserAuthority.isCustomer(userDetails.getUserAuthority())
-                && !userDetails.getUserId().equals(userId)) {
+        if ((UserAuthority.isCustomer(userDetails.getUserAuthority())
+            || UserAuthority.isOwner(userDetails.getUserAuthority()))
+            && !userDetails.getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.ORDER_PERMISSION_DENIED);
         }
 
@@ -164,5 +166,24 @@ public class OrderService {
         return orderRepository.findDetailById(orderId)
             .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
+    }
+
+    private void validatePermission(UserDetailsImpl userDetails, Order order) {
+        switch (userDetails.getUserAuthority()) {
+            case OWNER -> hasPermission(userDetails, order.getStore().getUser().getId());
+            case CUSTOMER -> hasPermission(userDetails, order.getUser().getId());
+        }
+    }
+
+    public OrderResponseDto cancelOrder(UUID orderId, UserDetailsImpl userDetails) {
+        Order targetOrder = orderRepository.findDetailById(orderId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        validatePermission(userDetails, targetOrder);
+
+        targetOrder.delete(userDetails.getUserId());
+        targetOrder.changeOrderStatus(OrderStatus.CANCELLED);
+
+        return orderMapper.toResponse(targetOrder);
     }
 }

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -175,6 +175,7 @@ public class OrderService {
         }
     }
 
+    @Transactional
     public OrderResponseDto cancelOrder(UUID orderId, UserDetailsImpl userDetails) {
         Order targetOrder = orderRepository.findDetailById(orderId)
             .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));

--- a/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/tdd/domain/order/service/OrderService.java
@@ -182,6 +182,9 @@ public class OrderService {
 
         validatePermission(userDetails, targetOrder);
 
+        if (!targetOrder.canCancel()) {
+            throw new BusinessException(ErrorCode.ORDER_CANCELLATION_NOT_ALLOWED);
+        }
         targetOrder.delete(userDetails.getUserId());
         targetOrder.changeOrderStatus(OrderStatus.CANCELLED);
 

--- a/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/tdd/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     MENU_NOT_IN_STORE(HttpStatus.BAD_REQUEST, "해당 가게의 메뉴가 아닙니다."),
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 메뉴가 포함되어 있습니다."),
     MENU_INVALID_INFO(HttpStatus.BAD_REQUEST, "메뉴 정보가 올바르지 않습니다."),
+    ORDER_CANCELLATION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "주문 생성 후 5분이 지나 취소할 수 없습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
 
     // MENU 도메인 관련

--- a/src/main/java/com/sparta/tdd/global/pageable/CustomPageableResolver.java
+++ b/src/main/java/com/sparta/tdd/global/pageable/CustomPageableResolver.java
@@ -16,12 +16,10 @@ public class CustomPageableResolver extends PageableHandlerMethodArgumentResolve
 
     private static final Set<Integer> ALLOWED = Set.of(10, 30, 50);
     private static final int DEFAULT_PAGE_SIZE = 10;
-    private static final int MAX_SIZE = 50;
 
     public CustomPageableResolver(SortHandlerMethodArgumentResolver sortResolver) {
         super(sortResolver);
         this.setFallbackPageable(PageRequest.of(0, DEFAULT_PAGE_SIZE));
-        this.setMaxPageSize(MAX_SIZE);
     }
 
     /**

--- a/src/test/java/com/sparta/tdd/domain/global/PageableStandaloneTest.java
+++ b/src/test/java/com/sparta/tdd/domain/global/PageableStandaloneTest.java
@@ -59,11 +59,11 @@ class PageableStandaloneTest {
     }
 
     @Test
-    @DisplayName("상한 후 허용: size=100 → 50")
+    @DisplayName("상한 후 허용: size=100 → 10")
     void capTo50() throws Exception {
         mvc.perform(get("/_probe/page").param("size", "100"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.size", is(50)));
+            .andExpect(jsonPath("$.size", is(10)));
     }
 
     @Test


### PR DESCRIPTION
## OrderService.cancelOrder
마스터, 매니저는 검증없이 통과합니다
오너는 Store 소유주와 Id 가 동일하여야 합니다
User 는 주문 소유주와 Id 가 동일하여야 합니다

## OrderStatus
취소 처리를 위해 OrderStatus 에 CANCELLED 추가 하였습니다
CANCELLED 는 next 로 상태변화를 시킬 수 없도록 하였습니다

## OrderRepositoryCustomImpl
Store.User 조회를 위해서 쿼리문 수정이 이루어졌습니다
조건에 맞는 User 만 단건 추가 join 이라 성능에 크게 변화는 없을 것이라고 예상 됩니다

## OrderController.cancelOrder
Status 와 delete 필드만 바꾸는 요청으로 PATCH 를 적용하였습니다
응답 값으로는 수정된 상태 전부를 반환하게 됩니다

----

fix(Order): cancelOrder 5분 이내 주문만 취소가능 조건 추가

## Order
canCancel 메서드 추가하였습니다 createAt 과 현재시간 비교후 5분 이내인지 확인

## ErrorCode
ORDER_CANCELLATION_NOT_ALLOWED 추가하였습니다

## OrderService
cancelOrder 부분 내부 로직 변경 되었습니다
Order.canCancel 로 확인 후 이후 상태변경 실행하는 방식으로 변경되었습니다

---

Order.canCancel 에서 상태변환까지 같이 담당하는 것이 좋을거 같다고 생각되나 요구사항에 맞춘 코드를 우선 PR 하였습니다

의견말씀해주시면 이후 Pr 에서 수정하도록 하겠습니다