### PR TITLE
feat(review): 리뷰 평점 n+1 문제 해결

### DIFF
--- a/src/main/java/com/sparta/tdd/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/tdd/domain/review/repository/ReviewRepository.java
@@ -56,5 +56,7 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     @Query("SELECT r.id FROM Review r WHERE r.store.id IN :storeIds AND r.deletedAt IS NULL")
     List<UUID> findReviewIdsByStoreIds(@Param("storeIds") List<UUID> storeIds);
 
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.store.id = :storeId AND r.deletedAt IS NULL")
+    Long countByStoreIdAndNotDeleted(@Param("storeId") UUID storeId);
 
 }

--- a/src/main/java/com/sparta/tdd/domain/store/entity/Store.java
+++ b/src/main/java/com/sparta/tdd/domain/store/entity/Store.java
@@ -90,4 +90,9 @@ public class Store extends BaseEntity {
     public boolean isOwner(User user) {
         return this.getUser().getId().equals(user.getId());
     }
+
+    public void updateRatingInfo(BigDecimal newAvgRating, Integer newReviewCount) {
+        this.avgRating = newAvgRating;
+        this.reviewCount = newReviewCount;
+    }
 }


### PR DESCRIPTION
# 리뷰 평점 N+1 문제를 해결하기 위한 PR 입니다.
# 참고로 이미 N+1 문제는 나지 않았지만 리뷰쪽에서 N+1 방지를 위한 코드가 부족하여 추가로 작성하였습니다.

1. 이미 store에 평점 컬럼이 있기 때문에
2.  리뷰가 CUD 될 때마다 이 리뷰를 최신화 시켜줘서 N+1 문제를 해결하였습니다.

모두가 아시겠지만 
# N+1 문제란? 
- 1개의 쿼리를 실행했을 때, 그 결과의 각 row마다 추가로 N개의 쿼리가 실행되는 문제
- 전에 코드가 그렇다는 거는 아니고 예시로 남겨두겠습니다.
```
List<Store> stores = storeRepository.findAll(); // 100개 조회

// 2. 각 Store의 리뷰 평점을 계산 (N번 쿼리)
for (Store store : stores) {
    // 각 Store마다 쿼리 실행 -> 100번 쿼리 발생!
    Double avgRating = reviewRepository.findAverageRatingByStoreId(store.getId());
    Long reviewCount = reviewRepository.countByStoreIdAndNotDeleted(store.getId());
    store.updateRatingInfo(...);
}
```
이렇게 해서 쿼리가 한번실행되는게 아니라 여러번 실행되는것을 N+1 이라고 합니다.
만약 위 코드 처럼 구성되어 있다면 Store의 수 만큼 쿼리가 더 실행되기 때문에 N+1 이라고 합니다.!

# 해결 방안
- Store에 미리 리뷰 평점 컬럼을 생성한다.
- 그리고 리뷰가 새로 생기거나 수정되거나 삭제될 때마다 업데이트 해주는 메서드를 만들어서 
- CUD 작업 때 평점을 최신화 해줍니다.
- 이러면 N만큼 쿼리가 실행되는게 아닌 고정된 쿼리 수 만큼 진행되기 때문에 문제 해결인거 같습니다.!

감사합니다.